### PR TITLE
[#6] 게시판 목록 조회

### DIFF
--- a/src/main/java/com/api/stuv/domain/board/controller/BoardController.java
+++ b/src/main/java/com/api/stuv/domain/board/controller/BoardController.java
@@ -22,7 +22,7 @@ public class BoardController {
     private final BoardService boardService;
 
     @Operation(summary = "게시판 목록 조회 API", description = "게시판 목록을 조회 합니다.")
-    @GetMapping("/board")
+    @GetMapping("")
     public ResponseEntity<ApiResponse<PageResponse<BoardResponse>>> getBoardList(@RequestParam(required = false, defaultValue = "") String title,
                                                                     @RequestParam(required = false, defaultValue = "0") Integer page,
                                                                     @RequestParam(required = false, defaultValue = "10") Integer size) {

--- a/src/main/java/com/api/stuv/domain/board/controller/BoardController.java
+++ b/src/main/java/com/api/stuv/domain/board/controller/BoardController.java
@@ -1,0 +1,34 @@
+package com.api.stuv.domain.board.controller;
+
+import com.api.stuv.domain.board.dto.BoardResponse;
+import com.api.stuv.domain.board.service.BoardService;
+import com.api.stuv.global.response.ApiResponse;
+import com.api.stuv.global.response.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import org.springframework.data.domain.Pageable;
+
+@RestController
+@RequestMapping("/api/board")
+@RequiredArgsConstructor
+@Tag(name = "Board", description = "게시판 관련 API")
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @Operation(summary = "게시판 목록 조회 API", description = "게시판 목록을 조회 합니다.")
+    @GetMapping("/board")
+    public ResponseEntity<ApiResponse<PageResponse<BoardResponse>>> getBoardList(@RequestParam(required = false, defaultValue = "") String title,
+                                                                    @RequestParam(required = false, defaultValue = "0") Integer page,
+                                                                    @RequestParam(required = false, defaultValue = "10") Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(boardService.getBoardList(title, pageable)));
+    }
+
+}

--- a/src/main/java/com/api/stuv/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/api/stuv/domain/board/dto/BoardResponse.java
@@ -1,0 +1,13 @@
+package com.api.stuv.domain.board.dto;
+
+import com.api.stuv.domain.board.entity.BoardType;
+
+public record BoardResponse (
+        Long boardId,
+        String title,
+        BoardType boardType,
+        boolean isConfirm,
+        String createdAt,
+        String imageUrl
+) {}
+

--- a/src/main/java/com/api/stuv/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/api/stuv/domain/board/dto/BoardResponse.java
@@ -14,11 +14,11 @@ public record BoardResponse (
             Long boardId,
             String title,
             BoardType boardType,
-            boolean isConfirm,
+            boolean confirmedCommentId,
             String createdAt,
             String image
     ) {
-        this(boardId, title, boardType.toString(), isConfirm, createdAt, image);
+        this(boardId, title, boardType.toString(), confirmedCommentId, createdAt, image);
     }
 }
 

--- a/src/main/java/com/api/stuv/domain/board/dto/BoardResponse.java
+++ b/src/main/java/com/api/stuv/domain/board/dto/BoardResponse.java
@@ -5,9 +5,20 @@ import com.api.stuv.domain.board.entity.BoardType;
 public record BoardResponse (
         Long boardId,
         String title,
-        BoardType boardType,
+        String boardType,
         boolean isConfirm,
         String createdAt,
-        String imageUrl
-) {}
+        String image
+) {
+    public BoardResponse(
+            Long boardId,
+            String title,
+            BoardType boardType,
+            boolean isConfirm,
+            String createdAt,
+            String image
+    ) {
+        this(boardId, title, boardType.toString(), isConfirm, createdAt, image);
+    }
+}
 

--- a/src/main/java/com/api/stuv/domain/board/entity/Board.java
+++ b/src/main/java/com/api/stuv/domain/board/entity/Board.java
@@ -19,6 +19,8 @@ public class Board extends BaseTimeEntity {
 
     private Long userId;
 
+    private Long confirmedCommentId;
+
     @Column(nullable = false)
     private String title;
 
@@ -28,6 +30,7 @@ public class Board extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private BoardType boardType;
+
 
     @Builder
     public Board(Long userId, String title, String context, BoardType boardType) {

--- a/src/main/java/com/api/stuv/domain/board/entity/BoardType.java
+++ b/src/main/java/com/api/stuv/domain/board/entity/BoardType.java
@@ -8,4 +8,9 @@ public enum BoardType {
     QUESTION("질문");
 
     private final String text;
+
+    @Override
+    public String toString() {
+        return text;
+    }
 }

--- a/src/main/java/com/api/stuv/domain/board/entity/Comment.java
+++ b/src/main/java/com/api/stuv/domain/board/entity/Comment.java
@@ -26,13 +26,10 @@ public class Comment extends BaseTimeEntity {
     @Column(nullable = false)
     private Long userId;
 
-    private Boolean isConfirm;
-
     @Builder
-    public Comment(Long boardId, String context, Long userId, Boolean isConfirm) {
+    public Comment(Long boardId, String context, Long userId) {
         this.boardId = boardId;
         this.context = context;
         this.userId = userId;
-        this.isConfirm = isConfirm;
     }
 }

--- a/src/main/java/com/api/stuv/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/api/stuv/domain/board/repository/BoardRepository.java
@@ -7,3 +7,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryCustom {
 }
+

--- a/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryCustom.java
@@ -1,5 +1,9 @@
 package com.api.stuv.domain.board.repository;
 
-public interface BoardRepositoryCustom {
+import com.api.stuv.domain.board.dto.BoardResponse;
+import com.api.stuv.global.response.PageResponse;
+import org.springframework.data.domain.Pageable;
 
+public interface BoardRepositoryCustom {
+    PageResponse<BoardResponse> getBoardList(String title, Pageable pageable, String imageUrl);
 }

--- a/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryImpl.java
@@ -1,12 +1,53 @@
 package com.api.stuv.domain.board.repository;
 
+import com.api.stuv.domain.board.dto.BoardResponse;
+import com.api.stuv.domain.board.entity.QBoard;
+import com.api.stuv.domain.board.entity.QComment;
+import com.api.stuv.global.response.PageResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.*;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class BoardRepositoryImpl implements BoardRepositoryCustom {
-
     private final JPAQueryFactory jpaQueryFactory;
+    private final QBoard b = QBoard.board;
+    private final QComment c = QComment.comment;
 
+    public PageResponse<BoardResponse> getBoardList(String title, Pageable pageable, String imageUrl) {
+        BooleanExpression isConfirm = JPAExpressions.selectOne().from(c)
+                .where(c.boardId.eq(b.id).and(c.isConfirm.eq(true))).exists();
 
+        JPAQuery<BoardResponse> query = jpaQueryFactory
+                .select(Projections.constructor(BoardResponse.class, b.id.as("boardId"), b.title, b.boardType, isConfirm, timeFormater(b.createdAt), getImageUrl(imageUrl, b.id).as("image")))
+                .from(b)
+                .where(b.title.contains(title));
+
+        return applyPage(query, pageable, getBoardCount(title));
+    }
+
+    public <T> PageResponse<T> applyPage(JPAQuery<T> query, Pageable pageable, Long count) {
+        List<T> content = query.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
+        return PageResponse.of(new PageImpl<>(content, pageable, count));
+    }
+
+    public Long getBoardCount(String title) {
+        return jpaQueryFactory.select(b.count()).from(b).where(b.title.contains(title)).fetchOne();
+    }
+
+    public StringTemplate timeFormater(DateTimePath<LocalDateTime> dateTimePath) {
+        return Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d %H:%i:%s')", dateTimePath);
+    }
+
+    public StringTemplate getImageUrl(String imageUrl, NumberPath<Long> id) {
+        return Expressions.stringTemplate("CONCAT({0}, {1})", imageUrl, id);
+    }
 }

--- a/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryImpl.java
@@ -21,6 +21,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
     private final QBoard b = QBoard.board;
     private final QComment c = QComment.comment;
 
+    @Override
     public PageResponse<BoardResponse> getBoardList(String title, Pageable pageable, String imageUrl) {
         JPAQuery<BoardResponse> query = jpaQueryFactory
                 .select(Projections.constructor(BoardResponse.class,
@@ -36,20 +37,20 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
         return applyPage(query, pageable, getBoardCount(title));
     }
 
-    public <T> PageResponse<T> applyPage(JPAQuery<T> query, Pageable pageable, Long count) {
+    private <T> PageResponse<T> applyPage(JPAQuery<T> query, Pageable pageable, Long count) {
         List<T> content = query.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
         return PageResponse.of(new PageImpl<>(content, pageable, count));
     }
 
-    public Long getBoardCount(String title) {
+    private Long getBoardCount(String title) {
         return jpaQueryFactory.select(b.count()).from(b).where(b.title.contains(title)).fetchOne();
     }
 
-    public StringTemplate timeFormater(DateTimePath<LocalDateTime> dateTimePath) {
+    private StringTemplate timeFormater(DateTimePath<LocalDateTime> dateTimePath) {
         return Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d %H:%i:%s')", dateTimePath);
     }
 
-    public StringTemplate getImageUrl(String imageUrl, NumberPath<Long> id) {
+    private StringTemplate getImageUrl(String imageUrl, NumberPath<Long> id) {
         return Expressions.stringTemplate("CONCAT({0}, {1})", imageUrl, id);
     }
 }

--- a/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryImpl.java
@@ -6,7 +6,6 @@ import com.api.stuv.domain.board.entity.QComment;
 import com.api.stuv.global.response.PageResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -23,11 +22,14 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
     private final QComment c = QComment.comment;
 
     public PageResponse<BoardResponse> getBoardList(String title, Pageable pageable, String imageUrl) {
-        BooleanExpression isConfirm = JPAExpressions.selectOne().from(c)
-                .where(c.boardId.eq(b.id).and(c.isConfirm.eq(true))).exists();
-
         JPAQuery<BoardResponse> query = jpaQueryFactory
-                .select(Projections.constructor(BoardResponse.class, b.id.as("boardId"), b.title, b.boardType, isConfirm, timeFormater(b.createdAt), getImageUrl(imageUrl, b.id).as("image")))
+                .select(Projections.constructor(BoardResponse.class,
+                        b.id.as("boardId"),
+                        b.title,
+                        b.boardType,
+                        b.confirmedCommentId.isNotNull(),
+                        timeFormater(b.createdAt),
+                        getImageUrl(imageUrl, b.id).as("image")))
                 .from(b)
                 .where(b.title.contains(title));
 

--- a/src/main/java/com/api/stuv/domain/board/service/BoardService.java
+++ b/src/main/java/com/api/stuv/domain/board/service/BoardService.java
@@ -1,0 +1,63 @@
+package com.api.stuv.domain.board.service;
+
+import com.api.stuv.domain.board.dto.BoardResponse;
+import com.api.stuv.domain.board.entity.QBoard;
+import com.api.stuv.domain.board.entity.QComment;
+import com.api.stuv.domain.board.repository.BoardRepository;
+import com.api.stuv.domain.board.repository.CommentRepository;
+import com.api.stuv.global.exception.BadRequestException;
+import com.api.stuv.global.exception.ErrorCode;
+import com.api.stuv.global.response.PageResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // TODO : 이후 이미지 다운로드 기능 추가해 주세요!
+    public PageResponse<BoardResponse> getBoardList(String title, Pageable pageable) {
+        QBoard b = QBoard.board;
+        QComment c = QComment.comment;
+
+        if ( pageable.getPageSize() < 1 ) throw new BadRequestException(ErrorCode.INVALID_PAGE_SIZE);
+
+        BooleanExpression isConfirm = JPAExpressions.selectOne().from(c)
+                .where(c.boardId.eq(b.id).and(c.isConfirm.eq(true))).exists();
+
+        JPAQuery<BoardResponse> query = jpaQueryFactory
+                .select(Projections.constructor(BoardResponse.class,
+                        b.id.as("boardId"), b.title, b.boardType, isConfirm,
+                        Expressions.stringTemplate("DATE_FORMAT({0}, '%Y-%m-%d %H:%i:%s')", b.createdAt),
+                        Expressions.stringTemplate("CONCAT('http://example.image.text/board/', {0})", b.id).as("imageUrl")))
+                .from(b)
+                .where(b.title.contains(title));
+
+        List<BoardResponse> content = query.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
+
+        Long pageCount = jpaQueryFactory.select(b.count()).from(b).where(b.title.contains(title)).fetchOne();
+
+        log.error("pageCount: " + pageCount + ", pageable.getPageNumber(): " + pageable.getPageNumber());
+
+        if ( pageCount == null || pageCount < pageable.getPageNumber() ) throw new BadRequestException(ErrorCode.INVALID_PAGE_NUMBER);
+
+        return PageResponse.of(new PageImpl<>(content, pageable, pageCount));
+    }
+}

--- a/src/main/java/com/api/stuv/domain/board/service/BoardService.java
+++ b/src/main/java/com/api/stuv/domain/board/service/BoardService.java
@@ -54,8 +54,6 @@ public class BoardService {
 
         Long pageCount = jpaQueryFactory.select(b.count()).from(b).where(b.title.contains(title)).fetchOne();
 
-        if ( pageCount == null || pageCount < pageable.getPageNumber() ) throw new BadRequestException(ErrorCode.INVALID_PAGE_NUMBER);
-
         return PageResponse.of(new PageImpl<>(content, pageable, pageCount));
     }
 }

--- a/src/main/java/com/api/stuv/domain/board/service/BoardService.java
+++ b/src/main/java/com/api/stuv/domain/board/service/BoardService.java
@@ -2,11 +2,8 @@ package com.api.stuv.domain.board.service;
 
 import com.api.stuv.domain.board.dto.BoardResponse;
 import com.api.stuv.domain.board.repository.BoardRepository;
-import com.api.stuv.domain.board.repository.BoardRepositoryCustom;
-import com.api.stuv.domain.board.repository.BoardRepositoryImpl;
 import com.api.stuv.domain.board.repository.CommentRepository;
 import com.api.stuv.global.response.PageResponse;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -19,11 +16,9 @@ public class BoardService {
 
     private final BoardRepository boardRepository;
     private final CommentRepository commentRepository;
-    private final JPAQueryFactory jpaQueryFactory;
 
     // TODO : 이후 이미지 다운로드 기능 추가해 주세요!
     public PageResponse<BoardResponse> getBoardList(String title, Pageable pageable) {
-        BoardRepositoryCustom boardRepositoryCustom = new BoardRepositoryImpl(jpaQueryFactory);
-        return boardRepositoryCustom.getBoardList(title, pageable, "http://localhost:8080/api/v1/board/image/");
+        return boardRepository.getBoardList(title, pageable, "http://localhost:8080/api/v1/board/image/");
     }
 }

--- a/src/main/java/com/api/stuv/domain/board/service/BoardService.java
+++ b/src/main/java/com/api/stuv/domain/board/service/BoardService.java
@@ -54,8 +54,6 @@ public class BoardService {
 
         Long pageCount = jpaQueryFactory.select(b.count()).from(b).where(b.title.contains(title)).fetchOne();
 
-        log.error("pageCount: " + pageCount + ", pageable.getPageNumber(): " + pageable.getPageNumber());
-
         if ( pageCount == null || pageCount < pageable.getPageNumber() ) throw new BadRequestException(ErrorCode.INVALID_PAGE_NUMBER);
 
         return PageResponse.of(new PageImpl<>(content, pageable, pageCount));

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepository.java
@@ -12,5 +12,5 @@ import java.util.List;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT COUNT(*) FROM User u WHERE u.id IN :idList")
-    int isDuplicateIds(@Param("idList") List<Long> idList);
+    Integer isDuplicateIds(@Param("idList") List<Long> idList);
 }

--- a/src/main/java/com/api/stuv/global/exception/ErrorCode.java
+++ b/src/main/java/com/api/stuv/global/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     UNAUTHORIZED(401, -3005, "토큰 정보가 만료되었거나 존재하지 않습니다."),
     FORBIDDEN(403, -3006, "접근 권한이 없습니다."),
     INVALID_SORT_TYPE(400, -3007, "올바르지 않은 정렬 타입입니다."),
+    INVALID_PAGE_SIZE(400, -3008, "올바르지 않은 페이지 사이즈입니다."),
+    INVALID_PAGE_NUMBER(400, -3009, "올바르지 않은 페이지 번호입니다."),
 
     // FRIEND
     FRIEND_NOT_FOUND(404, -4000, "해당 친구를 찾을 수 없습니다."),
@@ -36,6 +38,13 @@ public enum ErrorCode {
     FRIEND_REQUEST_ALREADY_EXIST(400, -4003, "이미 친구 요청을 보냈습니다."),
     FRIEND_REQUEST_NOT_AUTHORIZED(403, -4004, "해당 친구 요청에 대한 수락 권한이 없습니다."),
     FRIEND_REQUEST_ALREADY_ACCEPTED(400, -4005, "이미 친구 요청을 수락했습니다."),
+
+    // BOARD
+    BOARD_NOT_FOUND(404, -5000, "해당 게시글을 찾을 수 없습니다."),
+
+    // COMMENT
+    COMMENT_NOT_FOUND(404, -6000, "해당 댓글을 찾을 수 없습니다."),
+    COMMENT_ALREADY_CONFIRM(400, -6001, "이미 채택된 댓글이 있습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/api/stuv/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/api/stuv/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.api.stuv.global.exception;
 
 import com.api.stuv.global.response.ApiResponse;
+import com.querydsl.core.types.ExpressionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,15 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ApiResponse<Void>> handleDataAccessException(DataAccessException e) {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         log.error("[ERROR] handleDataAccessException - {}", e.getMessage());
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(ExpressionException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleExpressionException(ExpressionException e) {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        log.error("[ERROR] handleExpressionException - {}", e.getMessage());
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.error(errorCode.getMessage()));

--- a/src/main/java/com/api/stuv/global/response/PageResponse.java
+++ b/src/main/java/com/api/stuv/global/response/PageResponse.java
@@ -1,5 +1,7 @@
 package com.api.stuv.global.response;
 
+import com.api.stuv.global.exception.BadRequestException;
+import com.api.stuv.global.exception.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -26,6 +28,7 @@ public class PageResponse<T> {
     }
 
     public static <T> PageResponse<T> of(Page<T> page) {
+        if ( page.getNumber() + 1 > page.getTotalPages() ) throw new BadRequestException(ErrorCode.INVALID_PAGE_NUMBER);
         return new PageResponse<>(page);
     }
 }


### PR DESCRIPTION
## 📌 작업 설명
- 게시판 목록을 조회합니다

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #6 

## 🧑‍💻 요구 사항과 구현 내용
- 전체 게시판 목록을 조회 할 수 있습니다
- 게시물의 제목에 대해 검색이 가능합니다
- 페이지 네이션 가능합니다
- 페이지 네이션에 에러로직 추가되었습니다

## ✅ 피드백 반영사항
- [ ] 피드백 1
- [ ] 피드백 2 

## ✅ PR 포인트 & 궁금한 점
- 이미지 다운로드 부분은 TODO로 남겨놨습니다. 나중에 수정해주세요!
