### PR TITLE
[#19] 코스튬 목록 조회 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.api.stuv.domain.admin.controller;
 
 import com.api.stuv.domain.admin.dto.CreateCostumeRequest;
 import com.api.stuv.domain.admin.service.AdminService;
+import com.api.stuv.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,11 +19,11 @@ public class AdminController {
     private final AdminService adminService;
 
     @PostMapping(value = "/costume", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> createCostume(
+    public ResponseEntity<ApiResponse<Void>> createCostume(
             @RequestPart(value = "contents") @Valid CreateCostumeRequest request,
             @RequestPart(value = "image", required = false) MultipartFile file
     ){
         adminService.createCostume(request, file);
-        return ResponseEntity.status(HttpStatus.CREATED).body("");
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
     }
 }

--- a/src/main/java/com/api/stuv/domain/image/service/S3ImageService.java
+++ b/src/main/java/com/api/stuv/domain/image/service/S3ImageService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -34,5 +35,12 @@ public class S3ImageService {
 
     private static String generateKey(ImageType imageType, Long id, String fileName) {
         return String.format("%s/%d/%s", imageType.getPath(), id, fileName);
+    }
+
+    public String generateImageFile(ImageType imageType, Long id, String fileName) {
+        return s3Client.utilities().getUrl(GetUrlRequest.builder()
+                .bucket(bucket)
+                .key(generateKey(imageType, id, fileName))
+                .build()).toString();
     }
 }

--- a/src/main/java/com/api/stuv/domain/shop/controller/CostumeController.java
+++ b/src/main/java/com/api/stuv/domain/shop/controller/CostumeController.java
@@ -1,6 +1,6 @@
 package com.api.stuv.domain.shop.controller;
 
-import com.api.stuv.domain.shop.dto.CostumeListResponse;
+import com.api.stuv.domain.shop.dto.CostumeResponse;
 import com.api.stuv.domain.shop.service.CostumeService;
 import com.api.stuv.global.response.ApiResponse;
 import com.api.stuv.global.response.PageResponse;
@@ -20,7 +20,7 @@ public class CostumeController {
     private final CostumeService costumeService;
 
     @GetMapping(value = "/costume")
-    public ResponseEntity<ApiResponse<PageResponse<CostumeListResponse>>> listCostumes (
+    public ResponseEntity<ApiResponse<PageResponse<CostumeResponse>>> listCostumes (
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {

--- a/src/main/java/com/api/stuv/domain/shop/controller/CostumeController.java
+++ b/src/main/java/com/api/stuv/domain/shop/controller/CostumeController.java
@@ -1,0 +1,30 @@
+package com.api.stuv.domain.shop.controller;
+
+import com.api.stuv.domain.shop.dto.CostumeListResponse;
+import com.api.stuv.domain.shop.service.CostumeService;
+import com.api.stuv.global.response.ApiResponse;
+import com.api.stuv.global.response.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CostumeController {
+
+    private final CostumeService costumeService;
+
+    @GetMapping(value = "/costume")
+    public ResponseEntity<ApiResponse<PageResponse<CostumeListResponse>>> listCostumes (
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok().body(ApiResponse.success(
+                costumeService.getCostumeList(PageRequest.of(page, size))));
+    }
+}

--- a/src/main/java/com/api/stuv/domain/shop/dto/CostumeListResponse.java
+++ b/src/main/java/com/api/stuv/domain/shop/dto/CostumeListResponse.java
@@ -1,0 +1,10 @@
+package com.api.stuv.domain.shop.dto;
+
+import java.math.BigDecimal;
+
+public record CostumeListResponse(
+        Long costumeId,
+        String image,
+        String costumeName,
+        BigDecimal point
+) {}

--- a/src/main/java/com/api/stuv/domain/shop/dto/CostumeResponse.java
+++ b/src/main/java/com/api/stuv/domain/shop/dto/CostumeResponse.java
@@ -2,7 +2,7 @@ package com.api.stuv.domain.shop.dto;
 
 import java.math.BigDecimal;
 
-public record CostumeListResponse(
+public record CostumeResponse(
         Long costumeId,
         String image,
         String costumeName,

--- a/src/main/java/com/api/stuv/domain/shop/entity/Costume.java
+++ b/src/main/java/com/api/stuv/domain/shop/entity/Costume.java
@@ -18,7 +18,6 @@ public class Costume extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private Long imagefileId;
 
     @Column(nullable = false)

--- a/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepository.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CostumeRepository extends JpaRepository<Costume, Long> {
+public interface CostumeRepository extends JpaRepository<Costume, Long>, CostumeRepositoryCustom {
 }

--- a/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryCustom.java
@@ -1,9 +1,9 @@
 package com.api.stuv.domain.shop.repository;
 
-import com.api.stuv.domain.shop.dto.CostumeListResponse;
+import com.api.stuv.domain.shop.dto.CostumeResponse;
 import com.api.stuv.global.response.PageResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface CostumeRepositoryCustom {
-    PageResponse<CostumeListResponse> getCostumeList(Pageable pageable);
+    PageResponse<CostumeResponse> getCostumeList(Pageable pageable);
 }

--- a/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.api.stuv.domain.shop.repository;
+
+import com.api.stuv.domain.shop.dto.CostumeListResponse;
+import com.api.stuv.global.response.PageResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface CostumeRepositoryCustom {
+    PageResponse<CostumeListResponse> getCostumeList(Pageable pageable);
+}

--- a/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.api.stuv.domain.shop.repository;
+
+import com.api.stuv.domain.image.entity.ImageType;
+import com.api.stuv.domain.image.entity.QImageFile;
+import com.api.stuv.domain.image.service.S3ImageService;
+import com.api.stuv.domain.shop.dto.CostumeListResponse;
+import com.api.stuv.domain.shop.entity.QCostume;
+import com.api.stuv.global.response.PageResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CostumeRepositoryImpl implements CostumeRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QCostume qCostume = QCostume.costume;
+    private final QImageFile qImageFile = QImageFile.imageFile;
+    private final S3ImageService s3ImageService;
+
+    @Override
+    public PageResponse<CostumeListResponse> getCostumeList(Pageable pageable) {
+
+        long totalCount = jpaQueryFactory.selectFrom(qCostume).fetch().size();
+        List<CostumeListResponse> listResponses = jpaQueryFactory
+                .select(qCostume.id,
+                        qImageFile.newFilename,
+                        qCostume.costumeName,
+                        qCostume.point)
+                .from(qCostume)
+                .leftJoin(qImageFile)
+                .on(qImageFile.id.eq(qCostume.imagefileId))
+                .fetch()
+                .stream()
+                .map(tuple -> new CostumeListResponse(
+                        tuple.get(qCostume.id),
+                        s3ImageService.generateImageFile(ImageType.COSTUME, tuple.get(qCostume.id), tuple.get(qImageFile.newFilename)),
+                        tuple.get(qCostume.costumeName),
+                        tuple.get(qCostume.point)
+                )).toList();
+
+        return PageResponse.of(new PageImpl<>(listResponses, pageable, totalCount));
+    }
+}

--- a/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.api.stuv.domain.shop.repository;
 import com.api.stuv.domain.image.entity.ImageType;
 import com.api.stuv.domain.image.entity.QImageFile;
 import com.api.stuv.domain.image.service.S3ImageService;
-import com.api.stuv.domain.shop.dto.CostumeListResponse;
+import com.api.stuv.domain.shop.dto.CostumeResponse;
 import com.api.stuv.domain.shop.entity.QCostume;
 import com.api.stuv.global.response.PageResponse;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,10 +21,10 @@ public class CostumeRepositoryImpl implements CostumeRepositoryCustom {
     private final S3ImageService s3ImageService;
 
     @Override
-    public PageResponse<CostumeListResponse> getCostumeList(Pageable pageable) {
+    public PageResponse<CostumeResponse> getCostumeList(Pageable pageable) {
 
-        long totalCount = jpaQueryFactory.selectFrom(qCostume).fetch().size();
-        List<CostumeListResponse> listResponses = jpaQueryFactory
+        long totalCount = jpaQueryFactory.select(qCostume.count()).from(qCostume).fetchOne();
+        List<CostumeResponse> listResponses = jpaQueryFactory
                 .select(qCostume.id,
                         qImageFile.newFilename,
                         qCostume.costumeName,
@@ -32,9 +32,11 @@ public class CostumeRepositoryImpl implements CostumeRepositoryCustom {
                 .from(qCostume)
                 .leftJoin(qImageFile)
                 .on(qImageFile.id.eq(qCostume.imagefileId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch()
                 .stream()
-                .map(tuple -> new CostumeListResponse(
+                .map(tuple -> new CostumeResponse(
                         tuple.get(qCostume.id),
                         s3ImageService.generateImageFile(ImageType.COSTUME, tuple.get(qCostume.id), tuple.get(qImageFile.newFilename)),
                         tuple.get(qCostume.costumeName),

--- a/src/main/java/com/api/stuv/domain/shop/service/CostumeService.java
+++ b/src/main/java/com/api/stuv/domain/shop/service/CostumeService.java
@@ -1,6 +1,6 @@
 package com.api.stuv.domain.shop.service;
 
-import com.api.stuv.domain.shop.dto.CostumeListResponse;
+import com.api.stuv.domain.shop.dto.CostumeResponse;
 import com.api.stuv.domain.shop.repository.CostumeRepository;
 import com.api.stuv.global.response.PageResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,7 @@ public class CostumeService {
 
     private final CostumeRepository costumeRepository;
 
-    public PageResponse<CostumeListResponse> getCostumeList(Pageable pageable) {
+    public PageResponse<CostumeResponse> getCostumeList(Pageable pageable) {
         return costumeRepository.getCostumeList(pageable);
     }
 }

--- a/src/main/java/com/api/stuv/domain/shop/service/CostumeService.java
+++ b/src/main/java/com/api/stuv/domain/shop/service/CostumeService.java
@@ -1,0 +1,19 @@
+package com.api.stuv.domain.shop.service;
+
+import com.api.stuv.domain.shop.dto.CostumeListResponse;
+import com.api.stuv.domain.shop.repository.CostumeRepository;
+import com.api.stuv.global.response.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CostumeService {
+
+    private final CostumeRepository costumeRepository;
+
+    public PageResponse<CostumeListResponse> getCostumeList(Pageable pageable) {
+        return costumeRepository.getCostumeList(pageable);
+    }
+}


### PR DESCRIPTION
## 📌 작업 설명
- 등록된 코스튬 목록 조회 기능 입니다

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #19 

## 🧑‍💻 요구 사항과 구현 내용
- S3에 등록된 코스튬 이미지 목록 조회

## ✅ 피드백 반영사항
- [x] DTO 파일명 변경(CostumeList -> Costume)
- [x] totalCount 받아오는 쿼리문 수정
- [x] page 처리 쿼리문 추가

## ✅ PR 포인트 & 궁금한 점
