### PR TITLE
[#37] 코스튬 삭제 기능 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
@@ -26,4 +26,12 @@ public class AdminController {
         adminService.createCostume(request, file);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
     }
+
+    @DeleteMapping(value = "/costume/{costumeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteCostume(
+            @PathVariable("costumeId") long costumeId
+    ){
+        adminService.deleteCostume(costumeId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success());
+    }
 }

--- a/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
+++ b/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
@@ -4,6 +4,7 @@ import com.api.stuv.domain.admin.dto.CreateCostumeRequest;
 import com.api.stuv.domain.admin.exception.InvalidPointFormat;
 import com.api.stuv.domain.image.entity.ImageFile;
 import com.api.stuv.domain.image.entity.ImageType;
+import com.api.stuv.domain.image.exception.ImageFileNameNotFound;
 import com.api.stuv.domain.image.exception.ImageFileNotFound;
 import com.api.stuv.domain.image.exception.InvalidImageFileFormat;
 import com.api.stuv.domain.image.repository.ImageFileRepository;
@@ -35,6 +36,14 @@ public class AdminService {
         Costume costume = Costume.createCostumeContents(request.costumeName(), request.point());
         costumeRepository.save(costume);
         handleImage(costume, file);
+    }
+
+    public void deleteCostume(Long costumeId) {
+        Costume costume = costumeRepository.findById(costumeId).orElseThrow();
+        ImageFile imageFile = imageFileRepository.findById(costume.getImagefileId()).orElseThrow(ImageFileNameNotFound::new);
+        s3ImageService.deleteImageFile(ImageType.COSTUME, costume.getImagefileId(), imageFile.getNewFilename());
+        imageFileRepository.deleteById(costume.getImagefileId());
+        costumeRepository.delete(costume);
     }
 
     public void handleImage(Costume costume, MultipartFile file) {

--- a/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
+++ b/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
@@ -39,6 +39,7 @@ public class AdminService {
     }
 
     public void deleteCostume(Long costumeId) {
+        // todo : 커스튬 예외 develop 병합 시, 가져오기
         Costume costume = costumeRepository.findById(costumeId).orElseThrow();
         ImageFile imageFile = imageFileRepository.findById(costume.getImagefileId()).orElseThrow(ImageFileNameNotFound::new);
         s3ImageService.deleteImageFile(ImageType.COSTUME, costume.getImagefileId(), imageFile.getNewFilename());

--- a/src/main/java/com/api/stuv/domain/image/exception/ImageFileNameNotFound.java
+++ b/src/main/java/com/api/stuv/domain/image/exception/ImageFileNameNotFound.java
@@ -1,0 +1,10 @@
+package com.api.stuv.domain.image.exception;
+
+import com.api.stuv.global.exception.BusinessException;
+import com.api.stuv.global.exception.ErrorCode;
+
+public class ImageFileNameNotFound extends BusinessException {
+    public ImageFileNameNotFound() {
+        super(ErrorCode.IMAGE_NAME_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/api/stuv/domain/image/service/S3ImageService.java
+++ b/src/main/java/com/api/stuv/domain/image/service/S3ImageService.java
@@ -7,8 +7,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
 
@@ -42,5 +44,17 @@ public class S3ImageService {
                 .bucket(bucket)
                 .key(generateKey(imageType, id, fileName))
                 .build()).toString();
+    }
+
+    public void deleteImageFile(ImageType imageType, Long id, String fileName) {
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(generateKey(imageType, id, fileName))
+                    .build();
+            s3Client.deleteObject(request);
+        } catch (S3Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/api/stuv/global/exception/ErrorCode.java
+++ b/src/main/java/com/api/stuv/global/exception/ErrorCode.java
@@ -50,6 +50,9 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(404, -6000, "해당 댓글을 찾을 수 없습니다."),
     COMMENT_ALREADY_CONFIRM(400, -6001, "이미 채택된 댓글이 있습니다."),
     COMMENT_NOT_AUTHORIZED(403, -6002, "해당 댓글에 대한 권한이 없습니다."),
+
+    // IMAGE
+    IMAGE_NAME_NOT_FOUND(404, -8000, "해당 이미지를 찾을 수 없습니다.")
     ;
 
     private final int status;


### PR DESCRIPTION
## 📌 작업 설명
- 관리자에서의 코스튬 삭제 기능 구현했습니다

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #37 

## 🧑‍💻 요구 사항과 구현 내용
- s3에 저장된 이미지 삭제
- costume, imagefile 테이블 내 데이터 삭제

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
- costume 예외 처리 경우, 코스튬 수정 병합 후 추가할 예정입니다
