### PR TITLE
[#49] 게시글 이미지 등록 기능 추가 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
+++ b/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
@@ -7,11 +7,9 @@ import com.api.stuv.domain.image.entity.ImageFile;
 import com.api.stuv.domain.image.entity.ImageType;
 import com.api.stuv.domain.image.exception.ImageFileNameNotFound;
 import com.api.stuv.domain.image.exception.ImageFileNotFound;
-import com.api.stuv.domain.image.exception.InvalidImageFileFormat;
 import com.api.stuv.domain.image.repository.ImageFileRepository;
 import com.api.stuv.domain.image.service.ImageService;
 import com.api.stuv.domain.image.service.S3ImageService;
-import com.api.stuv.domain.image.util.FileUtils;
 import com.api.stuv.domain.shop.entity.Costume;
 import com.api.stuv.domain.shop.repository.CostumeRepository;
 import lombok.RequiredArgsConstructor;
@@ -56,13 +54,9 @@ public class AdminService {
     }
 
     public void handleImage(Costume costume, MultipartFile file) {
-        String extension = FileUtils.getExtension(file);
-        if(!imageService.isValidImageExtension(extension)) {throw new InvalidImageFileFormat();}
-        String newFileName = FileUtils.generateNewFilename();
-        String fullFileName = newFileName + "." + extension;
+        String fullFileName = imageService.getFileName(file);
         s3ImageService.uploadImageFile(file, ImageType.COSTUME, costume.getId(), fullFileName);
         ImageFile imageFile = ImageFile.createImageFile(file.getOriginalFilename(), fullFileName, ImageType.COSTUME);
-
         imageFileRepository.save(imageFile);
         costume.updateImageFile(imageFile.getId());
     }

--- a/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
+++ b/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
@@ -3,8 +3,8 @@ package com.api.stuv.domain.admin.service;
 import com.api.stuv.domain.admin.dto.CostumeRequest;
 import com.api.stuv.domain.admin.exception.CostumeNotFound;
 import com.api.stuv.domain.admin.exception.InvalidPointFormat;
+import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.entity.ImageFile;
-import com.api.stuv.domain.image.entity.ImageType;
 import com.api.stuv.domain.image.exception.ImageFileNameNotFound;
 import com.api.stuv.domain.image.exception.ImageFileNotFound;
 import com.api.stuv.domain.image.repository.ImageFileRepository;
@@ -48,16 +48,17 @@ public class AdminService {
     public void deleteCostume(Long costumeId) {
         Costume costume = costumeRepository.findById(costumeId).orElseThrow(CostumeNotFound::new);
         ImageFile imageFile = imageFileRepository.findById(costume.getImagefileId()).orElseThrow(ImageFileNameNotFound::new);
-        s3ImageService.deleteImageFile(ImageType.COSTUME, costume.getImagefileId(), imageFile.getNewFilename());
+        s3ImageService.deleteImageFile(EntityType.COSTUME, costume.getImagefileId(), imageFile.getNewFilename());
         imageFileRepository.deleteById(costume.getImagefileId());
         costumeRepository.delete(costume);
     }
 
     public void handleImage(Costume costume, MultipartFile file) {
         String fullFileName = imageService.getFileName(file);
-        s3ImageService.uploadImageFile(file, ImageType.COSTUME, costume.getId(), fullFileName);
-        ImageFile imageFile = ImageFile.createImageFile(file.getOriginalFilename(), fullFileName, ImageType.COSTUME);
-        imageFileRepository.save(imageFile);
-        costume.updateImageFile(imageFile.getId());
+        s3ImageService.uploadImageFile(file, EntityType.COSTUME, costume.getId(), fullFileName);
+        // todo : imageFile entity 변경에 따른 코스튬 리팩토링 필요
+        //ImageFile imageFile = ImageFile.createImageFile(file.getOriginalFilename(), fullFileName, EntityType.COSTUME);
+        //imageFileRepository.save(imageFile);
+        //costume.updateImageFile(imageFile.getId());
     }
 }

--- a/src/main/java/com/api/stuv/domain/board/entity/Board.java
+++ b/src/main/java/com/api/stuv/domain/board/entity/Board.java
@@ -18,6 +18,8 @@ public class Board extends BaseTimeEntity {
 
     private Long userId;
 
+    private Long imagefileId;
+
     private Long confirmedCommentId;
 
     @Column(nullable = false)
@@ -35,5 +37,9 @@ public class Board extends BaseTimeEntity {
         this.title = title;
         this.context = context;
         this.boardType = boardType;
+    }
+
+    public void updateImageFile(Long imagefileId) {
+        this.imagefileId = imagefileId;
     }
 }

--- a/src/main/java/com/api/stuv/domain/board/service/BoardService.java
+++ b/src/main/java/com/api/stuv/domain/board/service/BoardService.java
@@ -37,8 +37,6 @@ public class BoardService {
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
     private final ImageService imageService;
-    private final S3ImageService s3ImageService;
-    private final ImageFileRepository imageFileRepository;
 
     // TODO : 이후 이미지 다운로드 기능 추가해 주세요!
     @Transactional(readOnly = true)
@@ -49,15 +47,8 @@ public class BoardService {
     @Transactional
     public Map<String, Long> createBoard(Long userId, BoardRequest boardRequest, List<MultipartFile> files) {
         Long boardId = boardRepository.save(BoardRequest.from(userId, boardRequest)).getId();
-        if (files != null && !files.isEmpty()) { for (MultipartFile file : files) { handleImage(boardId, file); }}
+        if (files != null && !files.isEmpty()) { for (MultipartFile file : files) { imageService.handleImage(boardId, file, EntityType.BOARD); }}
         return Map.of("boardId", boardId);
-    }
-
-    public void handleImage(Long boardId, MultipartFile file) {
-        String fullFileName = imageService.getFileName(file);
-        s3ImageService.uploadImageFile(file, EntityType.BOARD, boardId, fullFileName);
-        ImageFile imageFile = ImageFile.createImageFile(file.getOriginalFilename(), fullFileName, boardId, EntityType.BOARD);
-        imageFileRepository.save(imageFile);
     }
 
     @Transactional

--- a/src/main/java/com/api/stuv/domain/friend/repository/FriendRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/friend/repository/FriendRepositoryImpl.java
@@ -4,7 +4,7 @@ import com.api.stuv.domain.friend.dto.FriendFollowListResponse;
 import com.api.stuv.domain.friend.dto.FriendResponse;
 import com.api.stuv.domain.friend.entity.FriendStatus;
 import com.api.stuv.domain.friend.entity.QFriend;
-import com.api.stuv.domain.image.entity.ImageType;
+import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.entity.QImageFile;
 import com.api.stuv.domain.image.service.S3ImageService;
 import com.api.stuv.domain.shop.entity.QCostume;
@@ -72,7 +72,7 @@ public class FriendRepositoryImpl implements FriendRepositoryCustom {
                         tuple.get(u.id),
                         tuple.get(u.nickname),
                         tuple.get(u.context),
-                        s3ImageService.generateImageFile(ImageType.COSTUME, tuple.get(i.id), tuple.get(i.newFilename)))).toList();
+                        s3ImageService.generateImageFile(EntityType.COSTUME, tuple.get(i.id), tuple.get(i.newFilename)))).toList();
         return PageResponse.of(new PageImpl<>(response, pageable, getTotalSearchUserPage(userId, target)));
     }
 

--- a/src/main/java/com/api/stuv/domain/image/entity/EntityType.java
+++ b/src/main/java/com/api/stuv/domain/image/entity/EntityType.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ImageType {
+public enum EntityType {
     BOARD("게시글","board"),
     EVENT("이벤트","event"),
     CONFIRM("인증","confirm"),

--- a/src/main/java/com/api/stuv/domain/image/entity/ImageFile.java
+++ b/src/main/java/com/api/stuv/domain/image/entity/ImageFile.java
@@ -22,17 +22,21 @@ public class ImageFile extends BaseTimeEntity {
     @Column(nullable = false)
     private String newFilename;
 
+    @Column(nullable = false)
+    private Long entityId;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private ImageType imageType;
+    private EntityType entityType;
 
-    public ImageFile(String originFilename, String newFilename, ImageType imageType) {
+    public ImageFile(String originFilename, String newFilename, Long entityId, EntityType entityType) {
         this.originFilename = originFilename;
         this.newFilename = newFilename;
-        this.imageType = imageType;
+        this.entityId = entityId;
+        this.entityType = entityType;
     }
 
-    public static ImageFile createImageFile(String originFilename, String newFilename, ImageType imageType) {
-        return new ImageFile(originFilename, newFilename, imageType);
+    public static ImageFile createImageFile(String originFilename, String newFilename, Long entityId, EntityType entityType) {
+        return new ImageFile(originFilename, newFilename, entityId, entityType);
     }
 }

--- a/src/main/java/com/api/stuv/domain/image/service/ImageService.java
+++ b/src/main/java/com/api/stuv/domain/image/service/ImageService.java
@@ -1,6 +1,9 @@
 package com.api.stuv.domain.image.service;
 
+import com.api.stuv.domain.image.entity.EntityType;
+import com.api.stuv.domain.image.entity.ImageFile;
 import com.api.stuv.domain.image.exception.InvalidImageFileFormat;
+import com.api.stuv.domain.image.repository.ImageFileRepository;
 import com.api.stuv.domain.image.util.FileUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +18,15 @@ import java.util.Set;
 public class ImageService {
 
     private static final Set<String> approveExtensions = Set.of("jpg", "jpeg", "png", "gif");
+    private final S3ImageService s3ImageService;
+    private final ImageFileRepository imageFileRepository;
+
+    public void handleImage(Long entityId, MultipartFile file, EntityType entityType) {
+        String fullFileName = getFileName(file);
+        s3ImageService.uploadImageFile(file, entityType, entityId, fullFileName);
+        ImageFile imageFile = ImageFile.createImageFile(file.getOriginalFilename(), fullFileName, entityId, entityType);
+        imageFileRepository.save(imageFile);
+    }
 
     public String getFileName(MultipartFile file) {
         String extension = FileUtils.getExtension(file);

--- a/src/main/java/com/api/stuv/domain/image/service/ImageService.java
+++ b/src/main/java/com/api/stuv/domain/image/service/ImageService.java
@@ -1,11 +1,27 @@
 package com.api.stuv.domain.image.service;
 
+import com.api.stuv.domain.image.exception.InvalidImageFileFormat;
+import com.api.stuv.domain.image.util.FileUtils;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 @Service
+@RequiredArgsConstructor
 public class ImageService {
+
     private static final Set<String> approveExtensions = Set.of("jpg", "jpeg", "png", "gif");
+
+    public String getFileName(MultipartFile file) {
+        String extension = FileUtils.getExtension(file);
+        if(!isValidImageExtension(extension)) {throw new InvalidImageFileFormat();}
+        return FileUtils.generateNewFilename() + "." + extension;
+    }
+
     public boolean isValidImageExtension(String extension) {
         return approveExtensions.contains(extension.toLowerCase());
     }

--- a/src/main/java/com/api/stuv/domain/image/service/S3ImageService.java
+++ b/src/main/java/com/api/stuv/domain/image/service/S3ImageService.java
@@ -1,6 +1,6 @@
 package com.api.stuv.domain.image.service;
 
-import com.api.stuv.domain.image.entity.ImageType;
+import com.api.stuv.domain.image.entity.EntityType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -22,11 +22,11 @@ public class S3ImageService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public void uploadImageFile(MultipartFile file, ImageType imageType, Long id, String fileName) {
+    public void uploadImageFile(MultipartFile file, EntityType entityType, Long id, String fileName) {
         try{
             PutObjectRequest request = PutObjectRequest.builder()
                     .bucket(bucket)
-                    .key(generateKey(imageType, id, fileName)) // s3 내부 저장 경로 설정
+                    .key(generateKey(entityType, id, fileName)) // s3 내부 저장 경로 설정
                     .contentType(file.getContentType()) // 파일 타입
                     .build();
             s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize())); // s3에 파일 업로드
@@ -35,22 +35,22 @@ public class S3ImageService {
         }
     }
 
-    private static String generateKey(ImageType imageType, Long id, String fileName) {
-        return String.format("%s/%d/%s", imageType.getPath(), id, fileName);
+    private static String generateKey(EntityType entityType, Long id, String fileName) {
+        return String.format("%s/%d/%s", entityType.getPath(), id, fileName);
     }
 
-    public String generateImageFile(ImageType imageType, Long id, String fileName) {
+    public String generateImageFile(EntityType entityType, Long id, String fileName) {
         return s3Client.utilities().getUrl(GetUrlRequest.builder()
                 .bucket(bucket)
-                .key(generateKey(imageType, id, fileName))
+                .key(generateKey(entityType, id, fileName))
                 .build()).toString();
     }
 
-    public void deleteImageFile(ImageType imageType, Long id, String fileName) {
+    public void deleteImageFile(EntityType entityType, Long id, String fileName) {
         try {
             DeleteObjectRequest request = DeleteObjectRequest.builder()
                     .bucket(bucket)
-                    .key(generateKey(imageType, id, fileName))
+                    .key(generateKey(entityType, id, fileName))
                     .build();
             s3Client.deleteObject(request);
         } catch (S3Exception e) {

--- a/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.api.stuv.domain.shop.repository;
 
 import com.api.stuv.domain.admin.exception.CostumeNotFound;
-import com.api.stuv.domain.image.entity.ImageType;
+import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.entity.QImageFile;
 import com.api.stuv.domain.image.service.S3ImageService;
 import com.api.stuv.domain.shop.dto.CostumeResponse;
@@ -39,7 +39,7 @@ public class CostumeRepositoryImpl implements CostumeRepositoryCustom {
                 .stream()
                 .map(tuple -> new CostumeResponse(
                         tuple.get(qCostume.id),
-                        s3ImageService.generateImageFile(ImageType.COSTUME, tuple.get(qCostume.id), tuple.get(qImageFile.newFilename)),
+                        s3ImageService.generateImageFile(EntityType.COSTUME, tuple.get(qCostume.id), tuple.get(qImageFile.newFilename)),
                         tuple.get(qCostume.costumeName),
                         tuple.get(qCostume.point)
                 )).toList();
@@ -64,7 +64,7 @@ public class CostumeRepositoryImpl implements CostumeRepositoryCustom {
                 .map(response -> new CostumeResponse(
                         null,
                         s3ImageService.generateImageFile(
-                                ImageType.COSTUME,
+                                EntityType.COSTUME,
                                 costumeId,
                                 response.get(qImageFile.newFilename)
                         ),


### PR DESCRIPTION
## 📌 작업 설명
- 게시글 등록에 다중 이미지 적용했습니다

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #49 

## 🧑‍💻 요구 사항과 구현 내용
- 게시글에 등록시, S3에 다중 이미지 등록 가능합니다 

## ✅ 피드백 반영사항
- [x] imagefile 리팩토링
- 이미지 엔티티 entityId 추가
- handleImage 공통 메서드 적용

## ✅ PR 포인트 & 궁금한 점
