### PR TITLE
[#56] 게시글 목록조회 이미지 추가 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/board/repository/BoardRepositoryCustom.java
@@ -6,6 +6,6 @@ import com.api.stuv.global.response.PageResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface BoardRepositoryCustom {
-    PageResponse<BoardResponse> getBoardList(String title, Pageable pageable, String imageUrl);
+    PageResponse<BoardResponse> getBoardList(String title, Pageable pageable);
     BoardDetailResponse getBoardDetail(Long boardId);
 }

--- a/src/main/java/com/api/stuv/domain/board/service/BoardService.java
+++ b/src/main/java/com/api/stuv/domain/board/service/BoardService.java
@@ -37,8 +37,6 @@ public class BoardService {
     private final BoardRepository boardRepository;
     private final CommentRepository commentRepository;
     private final ImageFileRepository imageFileRepository;
-    private final UserRepository userRepository;
-    private final ImageFileRepository imageFileRepository;
     private final ImageService imageService;
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/api/stuv/domain/board/service/BoardService.java
+++ b/src/main/java/com/api/stuv/domain/board/service/BoardService.java
@@ -11,7 +11,6 @@ import com.api.stuv.domain.board.repository.BoardRepository;
 import com.api.stuv.domain.board.repository.CommentRepository;
 import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.service.ImageService;
-import com.api.stuv.domain.user.repository.UserRepository;
 import com.api.stuv.global.exception.AccessDeniedException;
 import com.api.stuv.global.exception.ErrorCode;
 import com.api.stuv.global.exception.NotFoundException;
@@ -34,13 +33,11 @@ public class BoardService {
 
     private final BoardRepository boardRepository;
     private final CommentRepository commentRepository;
-    private final UserRepository userRepository;
     private final ImageService imageService;
 
-    // TODO : 이후 이미지 다운로드 기능 추가해 주세요!
     @Transactional(readOnly = true)
     public PageResponse<BoardResponse> getBoardList(String title, Pageable pageable) {
-        return boardRepository.getBoardList(title, pageable, "http://localhost:8080/api/v1/board/image/");
+        return boardRepository.getBoardList(title, pageable);
     }
 
     @Transactional

--- a/src/main/java/com/api/stuv/domain/image/service/ImageService.java
+++ b/src/main/java/com/api/stuv/domain/image/service/ImageService.java
@@ -9,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 @Service
@@ -23,9 +21,9 @@ public class ImageService {
 
     public void handleImage(Long entityId, MultipartFile file, EntityType entityType) {
         String fullFileName = getFileName(file);
-        s3ImageService.uploadImageFile(file, entityType, entityId, fullFileName);
         ImageFile imageFile = ImageFile.createImageFile(file.getOriginalFilename(), fullFileName, entityId, entityType);
         imageFileRepository.save(imageFile);
+        s3ImageService.uploadImageFile(file, entityType, entityId, fullFileName);
     }
 
     public String getFileName(MultipartFile file) {


### PR DESCRIPTION
## 📌 작업 설명
- 게시글 목록 조회 이미지 처리 추가 기능입니다

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #56 

## 🧑‍💻 요구 사항과 구현 내용
- 목록 조회시, 가장 처음의(오래된) 이미지 url 반환  

## ✅ 피드백 반영사항
- [x] 피드백 

## ✅ PR 포인트 & 궁금한 점
