### PR TITLE
[#60] 타인 정보 조회

### DIFF
--- a/src/main/java/com/api/stuv/domain/user/controller/UserController.java
+++ b/src/main/java/com/api/stuv/domain/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.api.stuv.domain.user.controller;
 
+import com.api.stuv.domain.auth.util.TokenUtil;
 import com.api.stuv.domain.user.dto.request.EmailCertificationRequest;
 import com.api.stuv.domain.user.dto.request.KakaoUserRequest;
 import com.api.stuv.domain.user.dto.request.UserRequest;
+import com.api.stuv.domain.user.dto.response.UserInformationResponse;
 import com.api.stuv.domain.user.service.KakaoService;
 import com.api.stuv.domain.user.service.UserService;
 import com.api.stuv.global.response.ApiResponse;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserService userservice;
     private final KakaoService kakaoService;
+    private final TokenUtil tokenUtil;
 
     @Operation(summary = "인증메일 전송 API", description = "인증 메일을 전송합니다.")
     @PostMapping("/auth/send")
@@ -65,5 +68,15 @@ public class UserController {
 
         return ResponseEntity.ok()
                 .body(ApiResponse.success());
+    }
+
+    @Operation(summary = "타인 정보 가져오기 API", description = "타인의 정보를 가져옵니다.")
+    @GetMapping("/{userId}")
+    private ResponseEntity<ApiResponse<UserInformationResponse>> getUserInformation(@PathVariable("userId") Long userId){
+        Long myId = tokenUtil.getUserId();
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(userservice.getUserInformation(userId, myId)));
+
     }
 }

--- a/src/main/java/com/api/stuv/domain/user/dto/response/UserInformationResponse.java
+++ b/src/main/java/com/api/stuv/domain/user/dto/response/UserInformationResponse.java
@@ -1,0 +1,9 @@
+package com.api.stuv.domain.user.dto.response;
+
+public record UserInformationResponse(
+        Long id,
+        String context,
+        String link,
+        String nickname
+) {
+}

--- a/src/main/java/com/api/stuv/domain/user/dto/response/UserInformationResponse.java
+++ b/src/main/java/com/api/stuv/domain/user/dto/response/UserInformationResponse.java
@@ -1,9 +1,12 @@
 package com.api.stuv.domain.user.dto.response;
 
+import com.api.stuv.domain.friend.entity.FriendStatus;
+
 public record UserInformationResponse(
         Long id,
         String context,
         String link,
-        String nickname
+        String nickname,
+        FriendStatus status
 ) {
 }

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
@@ -1,5 +1,8 @@
 package com.api.stuv.domain.user.repository;
 
+import com.api.stuv.domain.user.dto.response.UserInformationResponse;
+
 public interface UserRepositoryCustom {
     String getUserProfile(Long userCostumeId);
+    UserInformationResponse getUserInformation(Long userId, Long myId);
 }

--- a/src/main/java/com/api/stuv/domain/user/service/UserService.java
+++ b/src/main/java/com/api/stuv/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.api.stuv.domain.user.service;
 import com.api.stuv.domain.user.dto.request.EmailCertificationRequest;
 import com.api.stuv.domain.user.dto.request.KakaoUserRequest;
 import com.api.stuv.domain.user.dto.request.UserRequest;
+import com.api.stuv.domain.user.dto.response.UserInformationResponse;
 import com.api.stuv.domain.user.entity.RoleType;
 import com.api.stuv.domain.user.entity.User;
 import com.api.stuv.domain.user.repository.UserRepository;
@@ -110,5 +111,11 @@ public class UserService {
         if(userRepository.existsByNickname(nickname)){
             throw new DuplicateException(ErrorCode.NICKNAME_ALREADY_EXIST);
         }
+    }
+
+    public UserInformationResponse getUserInformation(Long userId, Long myId){
+        UserInformationResponse information = userRepository.getUserInformation(userId, myId);
+
+        return information;
     }
 }


### PR DESCRIPTION
## 📌 작업 설명
- 다른 사람의 정보를 조회할 수 있다

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #60 

## 🧑‍💻 요구 사항과 구현 내용
- 조회하려는 사람의 id, 자기소개, 링크, 닉네임, 프로필 사진, 친구 상태를 조회한다.

## ✅ 피드백 반영사항
- [ ] 추후 이미지 불러오기 구현

## ✅ PR 포인트 & 궁금한 점
