### PR TITLE
[#65] 게시글 상세조회 이미지 추가 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/board/service/BoardService.java
+++ b/src/main/java/com/api/stuv/domain/board/service/BoardService.java
@@ -51,7 +51,6 @@ public class BoardService {
         return Map.of("boardId", boardId);
     }
 
-    // TODO : 이후 이미지 기능 추가!
     @Transactional(readOnly = true)
     public BoardDetailResponse getBoardDetail(Long boardId) {
         return boardRepository.getBoardDetail(boardId);


### PR DESCRIPTION
## 📌 작업 설명
- 게시글 상세 조회 이미지 반환

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #65 

## 🧑‍💻 요구 사항과 구현 내용
- 게시글 상세조회에 대한 다중이미지 반환

## ✅ 피드백 반영사항
- [ ] 피드백

## ✅ PR 포인트 & 궁금한 점
