### PR TITLE
[#70] 게시글 삭제에서 이미지 삭제 추가 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/image/repository/ImageFileRepository.java
+++ b/src/main/java/com/api/stuv/domain/image/repository/ImageFileRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
     List<ImageFile> findAllByEntityIdAndEntityType(Long boardId, EntityType entityType);
+    void deleteByNewFilename(String filename);
 }


### PR DESCRIPTION
## 📌 작업 설명
- 게시글 삭제시 이미지 또한 삭제 됩니다

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #70 

## 🧑‍💻 요구 사항과 구현 내용
- DB에 저장된 이미지 내용 삭제
- S3에 저장된 이미지 내용 삭제

## ✅ 피드백 반영사항
- [ ] 피드백 

## ✅ PR 포인트 & 궁금한 점
