### PR TITLE
[#79] 사용자 이미지 정보 조회 추가 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/image/entity/EntityType.java
+++ b/src/main/java/com/api/stuv/domain/image/entity/EntityType.java
@@ -9,7 +9,7 @@ public enum EntityType {
     BOARD("게시글","board"),
     EVENT("이벤트","event"),
     CONFIRM("인증","confirm"),
-    COSTUME("코스튬","costume/costume");
+    COSTUME("코스튬","costume");
 
     private final String text;
     private final String path;

--- a/src/main/java/com/api/stuv/domain/user/dto/response/MyInformationResponse.java
+++ b/src/main/java/com/api/stuv/domain/user/dto/response/MyInformationResponse.java
@@ -7,7 +7,7 @@ public record MyInformationResponse(
         String context,
         String link,
         String nickname,
-        BigDecimal point
-        //TODO: 후에 프로필 이미지 추가해주세요!
+        BigDecimal point,
+        String profile
 ) {
 }

--- a/src/main/java/com/api/stuv/domain/user/dto/response/UserInformationResponse.java
+++ b/src/main/java/com/api/stuv/domain/user/dto/response/UserInformationResponse.java
@@ -1,12 +1,11 @@
 package com.api.stuv.domain.user.dto.response;
 
-import com.api.stuv.domain.friend.entity.FriendStatus;
-
 public record UserInformationResponse(
         Long id,
         String context,
         String link,
         String nickname,
+        String profile,
         String status
 ) {
 }


### PR DESCRIPTION
## 📌 작업 설명
- 사용자 정보 조회에 이미지 정보를 추가하였습니다

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #79 

## 🧑‍💻 요구 사항과 구현 내용
- 나의 이미지 정보 조회
- 남의 이미지 정보 조회

## ✅ 피드백 반영사항
- [x] 피드백 

## ✅ PR 포인트 & 궁금한 점
