### PR TITLE
[#104] 개인 날짜별 인증 이미지 조회 기능 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.api.stuv.domain.admin.controller;
 
 import com.api.stuv.domain.admin.dto.request.CostumeRequest;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
+import com.api.stuv.domain.image.dto.ImageResponse;
 import com.api.stuv.domain.admin.service.AdminService;
 import com.api.stuv.domain.admin.dto.response.AdminPartyGroupResponse;
 import com.api.stuv.global.response.ApiResponse;
@@ -72,5 +73,15 @@ public class AdminController {
             @RequestParam(required = false) LocalDate date
             ) {
         return ResponseEntity.ok().body(ApiResponse.success(adminService.getPartyAuthDetailWithMembers(partyId, date)));
+    }
+
+    @GetMapping(value = "/party/{partyId}/{memberId}")
+    @Operation(summary = "날짜별 회원 팟 인증 사진 조회 API", description = "날짜별 회원 팟 인증 사진을 조회합니다.")
+    public ResponseEntity<ApiResponse<ImageResponse>> getGroupMemberConfirmImageByDate (
+            @PathVariable Long partyId,
+            @PathVariable Long memberId,
+            @RequestParam LocalDate date
+    ) {
+        return ResponseEntity.ok().body(ApiResponse.success(adminService.getGroupMemberConfirmImageByDate(partyId, memberId, date)));
     }
 }

--- a/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
+++ b/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
@@ -5,6 +5,7 @@ import com.api.stuv.domain.admin.dto.request.CostumeRequest;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
 import com.api.stuv.domain.admin.exception.CostumeNotFound;
 import com.api.stuv.domain.admin.exception.InvalidPointFormat;
+import com.api.stuv.domain.image.dto.ImageResponse;
 import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.entity.ImageFile;
 import com.api.stuv.domain.image.exception.ImageFileNotFound;
@@ -12,6 +13,8 @@ import com.api.stuv.domain.image.repository.ImageFileRepository;
 import com.api.stuv.domain.image.service.ImageService;
 import com.api.stuv.domain.image.service.S3ImageService;
 import com.api.stuv.domain.admin.dto.response.AdminPartyGroupResponse;
+import com.api.stuv.domain.party.entity.PartyGroup;
+import com.api.stuv.domain.party.repository.confirm.QuestConfirmRepository;
 import com.api.stuv.domain.party.repository.member.GroupMemberRepository;
 import com.api.stuv.domain.party.repository.party.PartyGroupRepository;
 import com.api.stuv.domain.shop.entity.Costume;
@@ -40,6 +43,7 @@ public class AdminService {
     private final ImageService imageService;
     private final PartyGroupRepository partyGroupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final QuestConfirmRepository questConfirmRepository;
 
     @Transactional
     public void createCostume(CostumeRequest request, MultipartFile file) {
@@ -79,5 +83,12 @@ public class AdminService {
         List<MemberDetailDTO> members = groupMemberRepository.findMemberListWithConfirmedByDate(partyId, date);
 
         return AdminPartyAuthDetailResponse.from(response, members);
+    }
+
+    public ImageResponse getGroupMemberConfirmImageByDate(Long partyId, Long memberId, LocalDate date) {
+        PartyGroup partyGroup = partyGroupRepository.findById(partyId).orElseThrow(() -> new NotFoundException(ErrorCode.PARTY_NOT_FOUND));
+        if (date.isBefore(partyGroup.getStartDate()) || date.isAfter(partyGroup.getEndDate())) throw new DateOutOfRangeException(ErrorCode.PARTY_INVALID_DATE);
+
+        return questConfirmRepository.findGroupMemberConfirmImageByDate(memberId, date);
     }
 }

--- a/src/main/java/com/api/stuv/domain/image/dto/ImageResponse.java
+++ b/src/main/java/com/api/stuv/domain/image/dto/ImageResponse.java
@@ -1,0 +1,5 @@
+package com.api.stuv.domain.image.dto;
+
+public record ImageResponse(
+        String image
+) {}

--- a/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepository.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface QuestConfirmRepository extends JpaRepository<QuestConfirm, Long> {
+public interface QuestConfirmRepository extends JpaRepository<QuestConfirm, Long>, QuestConfirmRepositoryCustom {
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.api.stuv.domain.party.repository.confirm;
+
+import com.api.stuv.domain.image.dto.ImageResponse;
+
+import java.time.LocalDate;
+
+public interface QuestConfirmRepositoryCustom {
+    ImageResponse findGroupMemberConfirmImageByDate(Long memberId, LocalDate date);
+}

--- a/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.api.stuv.domain.party.repository.confirm;
+
+import com.api.stuv.domain.image.dto.ImageResponse;
+import com.api.stuv.domain.image.entity.EntityType;
+import com.api.stuv.domain.image.entity.QImageFile;
+import com.api.stuv.domain.image.service.S3ImageService;
+import com.api.stuv.domain.party.entity.QQuestConfirm;
+import com.api.stuv.global.exception.ErrorCode;
+import com.api.stuv.global.exception.NotFoundException;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+
+@RequiredArgsConstructor
+public class QuestConfirmRepositoryImpl implements QuestConfirmRepositoryCustom {
+
+    private final JPAQueryFactory factory;
+    private final S3ImageService s3ImageService;
+    private final QQuestConfirm qc = QQuestConfirm.questConfirm;
+    private final QImageFile i = QImageFile.imageFile;
+
+    @Override
+    public ImageResponse findGroupMemberConfirmImageByDate(Long memberId, LocalDate date) {
+        return factory.select(qc.memberId, i.newFilename)
+                .from(qc)
+                .leftJoin(i).on(qc.memberId.eq(i.entityId)
+                        .and(i.entityType.eq(EntityType.CONFIRM)))
+                .where(qc.memberId.eq(memberId)
+                        .and(qc.confirmDate.eq(date)))
+                .fetch()
+                .stream()
+                .map(tp -> {
+                    if (tp.get(i.newFilename) == null) throw new NotFoundException(ErrorCode.CONFIRM_IMAGE_NOT_FOUND);
+                    return new ImageResponse(s3ImageService.generateImageFile(EntityType.CONFIRM, tp.get(qc.memberId), tp.get(i.newFilename)));
+                })
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(ErrorCode.CONFIRM_IMAGE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/api/stuv/global/exception/DateOutOfRangeException.java
+++ b/src/main/java/com/api/stuv/global/exception/DateOutOfRangeException.java
@@ -3,11 +3,8 @@ package com.api.stuv.global.exception;
 import lombok.Getter;
 
 @Getter
-public class DateOutOfRangeException extends RuntimeException {
-    private final ErrorCode errorCode;
-
+public class DateOutOfRangeException extends BusinessException {
     public DateOutOfRangeException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 }

--- a/src/main/java/com/api/stuv/global/exception/ErrorCode.java
+++ b/src/main/java/com/api/stuv/global/exception/ErrorCode.java
@@ -38,6 +38,8 @@ public enum ErrorCode {
     INVALID_PAGE_NUMBER(400, -3009, "올바르지 않은 페이지 번호입니다."),
     HTTP_API_ERROR(400, -3010, "HTTP API에서 오류가 발생했습니다."),
     JSON_PARSING_ERROR(400, -3011, "JSON 파싱이 잘못되었습니다."),
+    ARGUMENT_TYPE_MISMATCH(400, -3012, "파라미터의 값이 올바르지 않습니다."),
+    DATE_FORMAT_MISMATCH(400, -3013, "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"),
 
     // FRIEND
     FRIEND_NOT_FOUND(404, -4000, "해당 친구를 찾을 수 없습니다."),
@@ -68,6 +70,7 @@ public enum ErrorCode {
     // PARTY
     PARTY_NOT_FOUND(404, -9000, "해당 팟을 팢을 수 없습니다."),
     PARTY_INVALID_DATE(400, -9001, "해당 날짜는 팟의 인증 기간이 아닙니다."),
+    CONFIRM_IMAGE_NOT_FOUND(404, -9002, "해당 회원의 인증 이미지를 찾을 수 없습니다.")
     ;
 
     private final int status;

--- a/src/main/java/com/api/stuv/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/api/stuv/global/exception/GlobalExceptionHandler.java
@@ -5,8 +5,11 @@ import com.querydsl.core.types.ExpressionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.format.DateTimeParseException;
 
 @Slf4j
 @RestControllerAdvice
@@ -20,6 +23,32 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getStatus())
                 .body(ApiResponse.error(errorCode.getMessage()));
     }
+
+    // 타입 변환 관련 예외
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        ErrorCode errorCode = ErrorCode.ARGUMENT_TYPE_MISMATCH;
+        String paramName = e.getMethodParameter().getParameterName();
+        Class<?> requiredTypeClass = e.getMethodParameter().getParameterType();
+        String requiredType = requiredTypeClass.getSimpleName();
+        String errorMessage = String.format("%s (파라미터명: %s, 요구 타입: %s)",
+                errorCode.getMessage(), paramName, requiredType);
+        log.error("[ERROR] methodArgumentTypeMismatchException - {}", e.getMessage());
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorMessage));
+    }
+
+    // 날짜 변환 관련 예외
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDateTimeParseException(DateTimeParseException e) {
+        ErrorCode errorCode = ErrorCode.DATE_FORMAT_MISMATCH;
+        log.error("[ERROR] dateTimeParseException - {}", e.getMessage());
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode.getMessage()));
+    }
+
 
     @ExceptionHandler(ExpressionException.class)
     protected ResponseEntity<ApiResponse<Void>> handleExpressionException(ExpressionException e) {


### PR DESCRIPTION
## 📌 작업 설명
- 개인 날짜별 인증 이미지 조회

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #104 

## 🧑‍💻 요구 사항과 구현 내용
- 날짜 범위에 대한 예외처리 추가
- 날짜 포맷 변환에 대한 예외처리 추가
- 파라미터 타입 변환에 대한 예외처리 추가
- 개인 날짜별 인증 이미지 조회 기능 구현

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
