### PR TITLE
[#108] 본인 작성글 조회 기능 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/user/controller/UserController.java
+++ b/src/main/java/com/api/stuv/domain/user/controller/UserController.java
@@ -131,4 +131,12 @@ public class UserController {
         return ResponseEntity.ok()
                 .body(ApiResponse.success());
     }
+
+    @Operation(summary = "본인 작성 게시글 조회 API", description = "본인이 작성했던 글 목록을 조회하는 API 입니다.")
+    @GetMapping("/board")
+    private ResponseEntity<ApiResponse<List<UserBoardListResponse>>> getUserBoardList() {
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(userService.getUserBoardList()));
+    }
 }

--- a/src/main/java/com/api/stuv/domain/user/dto/response/UserBoardListResponse.java
+++ b/src/main/java/com/api/stuv/domain/user/dto/response/UserBoardListResponse.java
@@ -6,7 +6,7 @@ public record UserBoardListResponse(
         Long boardId,
         String title,
         String context,
-        String boardtype,
+        String boardType,
         String createAt,
         String image
 ) {

--- a/src/main/java/com/api/stuv/domain/user/dto/response/UserBoardListResponse.java
+++ b/src/main/java/com/api/stuv/domain/user/dto/response/UserBoardListResponse.java
@@ -1,0 +1,23 @@
+package com.api.stuv.domain.user.dto.response;
+
+import com.api.stuv.domain.board.entity.BoardType;
+
+public record UserBoardListResponse(
+        Long boardId,
+        String title,
+        String context,
+        String boardtype,
+        String createAt,
+        String image
+) {
+    public UserBoardListResponse(
+            Long boardId,
+            String title,
+            String context,
+            BoardType boardType,
+            String createdAt,
+            String image
+    ) {
+        this(boardId, title, context, boardType.toString(), createdAt, image);
+    }
+}

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.api.stuv.domain.user.repository;
 
+import com.api.stuv.domain.user.dto.response.UserBoardListResponse;
 import com.api.stuv.domain.user.dto.response.UserInformationResponse;
 import com.api.stuv.domain.user.dto.response.MyInformationResponse;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface UserRepositoryCustom {
     UserInformationResponse getUserInformation(Long userId, Long myId);
     MyInformationResponse getUserByMyId(@Param("myId") Long myId);
+    List<UserBoardListResponse> getUserBoardList(@Param("userId") Long userId);
 }

--- a/src/main/java/com/api/stuv/domain/user/service/UserService.java
+++ b/src/main/java/com/api/stuv/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.api.stuv.domain.user.service;
 import com.api.stuv.domain.auth.util.TokenUtil;
 import com.api.stuv.domain.user.dto.request.*;
 import com.api.stuv.domain.user.dto.response.ModifyProfileResponse;
+import com.api.stuv.domain.user.dto.response.UserBoardListResponse;
 import com.api.stuv.domain.user.dto.response.UserInformationResponse;
 import com.api.stuv.domain.user.dto.response.MyInformationResponse;
 import com.api.stuv.domain.user.entity.User;
@@ -24,6 +25,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.List;
 
 
 @Service
@@ -143,5 +145,14 @@ public class UserService {
 
         ModifyProfileResponse modifyProfileResponse = new ModifyProfileResponse(userId);
         return modifyProfileResponse;
+    }
+
+    public List<UserBoardListResponse> getUserBoardList(){
+        Long userId = tokenUtil.getUserId();
+
+        List<UserBoardListResponse> userBoardList = userRepository.getUserBoardList(userId);
+
+        return userBoardList;
+
     }
 }


### PR DESCRIPTION
## 📌 작업 설명
- 본인이 작성한 글 목록(제목, 내용, 타입, 사진)을 볼 수 있다

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #108 

## 🧑‍💻 요구 사항과 구현 내용
- board 테이블에 저장된 게시글과 images_file 테이블에 있는 이미지 파일을 결합해
- 목록으로 반환

## ✅ 피드백 반영사항
- [ ] 피드백 1
- [ ] 피드백 2 

## ✅ PR 포인트 & 궁금한 점
