### PR TITLE
[#110] 회원의 날짜별 팟 인증에 대한 상태 변경 기능 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
@@ -1,10 +1,12 @@
 package com.api.stuv.domain.admin.controller;
 
+import com.api.stuv.domain.admin.dto.request.ConfirmRequest;
 import com.api.stuv.domain.admin.dto.request.CostumeRequest;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
 import com.api.stuv.domain.image.dto.ImageResponse;
 import com.api.stuv.domain.admin.service.AdminService;
 import com.api.stuv.domain.admin.dto.response.AdminPartyGroupResponse;
+import com.api.stuv.global.exception.ValidationException;
 import com.api.stuv.global.response.ApiResponse;
 import com.api.stuv.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,7 +73,7 @@ public class AdminController {
     public ResponseEntity<ApiResponse<AdminPartyAuthDetailResponse>> getPartyAuthDetailWithMembers (
             @PathVariable Long partyId,
             @RequestParam(required = false) LocalDate date
-            ) {
+    ) {
         return ResponseEntity.ok().body(ApiResponse.success(adminService.getPartyAuthDetailWithMembers(partyId, date)));
     }
 
@@ -83,5 +85,18 @@ public class AdminController {
             @RequestParam LocalDate date
     ) {
         return ResponseEntity.ok().body(ApiResponse.success(adminService.getGroupMemberConfirmImageByDate(partyId, memberId, date)));
+    }
+
+    @PatchMapping(value = "/party/{partyId}/{memberId}")
+    @Operation(summary = "팟 날짜별 인증 이미지에 대한 승인 여부 처리 API", description = "팟 날짜별 인증 이미지에 대한 승인 여부를 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> changeGroupMemberConfirmedStatusByDate(
+            @PathVariable Long partyId,
+            @PathVariable Long memberId,
+            @RequestBody ConfirmRequest request
+    ) {
+        if (request.date() == null || request.auth() == null) throw new ValidationException();
+        adminService.changGroupMemberConfirmedStatusByDate(partyId, memberId, request);
+
+        return ResponseEntity.ok().body(ApiResponse.success());
     }
 }

--- a/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
@@ -95,7 +95,7 @@ public class AdminController {
             @RequestBody ConfirmRequest request
     ) {
         if (request.date() == null || request.auth() == null) throw new ValidationException();
-        adminService.changGroupMemberConfirmedStatusByDate(partyId, memberId, request);
+        adminService.changeGroupMemberConfirmedStatusByDate(partyId, memberId, request);
 
         return ResponseEntity.ok().body(ApiResponse.success());
     }

--- a/src/main/java/com/api/stuv/domain/admin/dto/request/ConfirmRequest.java
+++ b/src/main/java/com/api/stuv/domain/admin/dto/request/ConfirmRequest.java
@@ -1,0 +1,11 @@
+package com.api.stuv.domain.admin.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record ConfirmRequest(
+        @NotNull LocalDate date,
+        @NotNull Boolean auth
+) {
+}

--- a/src/main/java/com/api/stuv/domain/admin/dto/request/ConfirmRequest.java
+++ b/src/main/java/com/api/stuv/domain/admin/dto/request/ConfirmRequest.java
@@ -1,7 +1,5 @@
 package com.api.stuv.domain.admin.dto.request;
 
-import jakarta.validation.constraints.NotNull;
-
 import java.time.LocalDate;
 
 public record ConfirmRequest(

--- a/src/main/java/com/api/stuv/domain/admin/dto/request/ConfirmRequest.java
+++ b/src/main/java/com/api/stuv/domain/admin/dto/request/ConfirmRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record ConfirmRequest(
-        @NotNull LocalDate date,
-        @NotNull Boolean auth
+        LocalDate date,
+        Boolean auth
 ) {
 }

--- a/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
+++ b/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
@@ -100,7 +100,7 @@ public class AdminService {
     }
 
     @Transactional
-    public void changGroupMemberConfirmedStatusByDate(Long partyId, Long memberId, ConfirmRequest request) {
+    public void changeGroupMemberConfirmedStatusByDate(Long partyId, Long memberId, ConfirmRequest request) {
         PartyGroup party = partyGroupRepository.findById(partyId).orElseThrow(() -> new NotFoundException(ErrorCode.PARTY_NOT_FOUND));
 
         if (request.date().isBefore(party.getStartDate()) || request.date().isAfter(party.getEndDate())) throw new DateOutOfRangeException(ErrorCode.PARTY_INVALID_DATE);

--- a/src/main/java/com/api/stuv/domain/party/entity/GroupMember.java
+++ b/src/main/java/com/api/stuv/domain/party/entity/GroupMember.java
@@ -23,7 +23,7 @@ public class GroupMember {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private QuestStatus questStatus = QuestStatus.PROGRESS;
+    private QuestStatus questStatus;
 
     @Column(precision = 10)
     private BigDecimal bettingPoint;

--- a/src/main/java/com/api/stuv/domain/party/entity/GroupMember.java
+++ b/src/main/java/com/api/stuv/domain/party/entity/GroupMember.java
@@ -23,8 +23,15 @@ public class GroupMember {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private QuestStatus questStatus;
+    private QuestStatus questStatus = QuestStatus.PROGRESS;
 
     @Column(precision = 10)
     private BigDecimal bettingPoint;
+
+    @PrePersist
+    public void prePersist() {
+        if (questStatus == null) {
+            this.questStatus = QuestStatus.PROGRESS;
+        }
+    }
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.api.stuv.domain.party.repository.confirm;
 
-import com.api.stuv.domain.image.dto.ImageResponse;
+import com.api.stuv.domain.party.entity.ConfirmStatus;
+import com.querydsl.core.Tuple;
 
 import java.time.LocalDate;
 
 public interface QuestConfirmRepositoryCustom {
-    ImageResponse findGroupMemberConfirmImageByDate(Long memberId, LocalDate date);
+    Tuple findGroupMemberConfirmImageByDate(Long partyId, Long memberId, LocalDate date);
+    void updateConfirmStatusByDate(Long memberId, ConfirmStatus status, LocalDate date);
+    boolean isSuccessStatusDuringPeriod(Long memberId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryCustom.java
@@ -1,10 +1,13 @@
 package com.api.stuv.domain.party.repository.member;
 
 import com.api.stuv.domain.admin.dto.MemberDetailDTO;
+import com.api.stuv.domain.party.entity.QuestStatus;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface GroupMemberRepositoryCustom {
     List<MemberDetailDTO> findMemberListWithConfirmedByDate(Long partyId, LocalDate date);
+    void updateQuestStatusForMember(Long partyId, Long memberId, QuestStatus questStatus);
+    boolean isMemberNotProgressByGroupId(Long partyId);
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.api.stuv.domain.party.repository.party;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
 import com.api.stuv.domain.admin.dto.response.AdminPartyGroupResponse;
 import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
+import com.api.stuv.domain.party.entity.PartyStatus;
 import com.api.stuv.global.response.PageResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -13,4 +14,5 @@ public interface PartyGroupRepositoryCustom {
     List<PartyGroupResponse> findActivePartyGroupsByUserId(Long userId);
     PageResponse<AdminPartyGroupResponse> findAllPartyGroupsWithApproved(Pageable pageable);
     AdminPartyAuthDetailResponse findPartyGroupById(Long partyId);
+    void updatePartyStatusForPartyGroup(Long partyId, PartyStatus partyStatus);
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
@@ -24,11 +24,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
 
-    private static final Logger log = LoggerFactory.getLogger(PartyGroupRepositoryImpl.class);
     private final JPAQueryFactory factory;
     private final QPartyGroup pg = QPartyGroup.partyGroup;
     private final QGroupMember gm = QGroupMember.groupMember;
-    private final QQuestConfirm qc = QQuestConfirm.questConfirm;
 
     @Override
     public PageResponse<PartyGroupResponse> findPendingGroupsByName(String name, Pageable pageable) {
@@ -118,5 +116,13 @@ public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
                 .from(pg)
                 .where(pg.id.eq(partyId))
                 .fetchOne();
+    }
+
+    @Override
+    public void updatePartyStatusForPartyGroup(Long partyId, PartyStatus partyStatus) {
+        factory.update(pg)
+                .set(pg.status, partyStatus)
+                .where(pg.id.eq(partyId))
+                .execute();
     }
 }

--- a/src/main/java/com/api/stuv/global/exception/ErrorCode.java
+++ b/src/main/java/com/api/stuv/global/exception/ErrorCode.java
@@ -16,7 +16,6 @@ public enum ErrorCode {
     INVALID_PASSWORD(400, -1006, "아이디 또는 비밀번호가 올바르지 않습니다."),
     USER_NOT_FOUND(404, -1007, "존재하지 않는 사용자입니다."),
     DATA_ACCESS_API(401, -1008, "데이터를 받아오지 못했습니다"),
-    QUEST_ALREADY_REWARD(400, -1009, "보상을 이미 받았습니다."),
 
     // TOKEN
     EMPTY_JWT_TOKEN(400, -2000, "JWT 토큰이 없습니다."),
@@ -39,8 +38,9 @@ public enum ErrorCode {
     INVALID_PAGE_NUMBER(400, -3009, "올바르지 않은 페이지 번호입니다."),
     HTTP_API_ERROR(400, -3010, "HTTP API에서 오류가 발생했습니다."),
     JSON_PARSING_ERROR(400, -3011, "JSON 파싱이 잘못되었습니다."),
-    ARGUMENT_TYPE_MISMATCH(400, -3012, "파라미터의 값이 올바르지 않습니다."),
+    ARGUMENT_TYPE_MISMATCH(400, -3012, "올바르지 않은 파라미터입니다."),
     DATE_FORMAT_MISMATCH(400, -3013, "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"),
+    INVALID_ARGUMENT_METHOD(400, -3014, "데이터 유효성 검증에 실패했습니다."),
 
     // FRIEND
     FRIEND_NOT_FOUND(404, -4000, "해당 친구를 찾을 수 없습니다."),
@@ -78,9 +78,9 @@ public enum ErrorCode {
     CHAT_ROOM_NOT_FOUND(404, -10000, "채팅방을 찾을 수 없습니다."),
 
     // PARTY
-    PARTY_NOT_FOUND(404, -9000, "해당 팟을 팢을 수 없습니다."),
-    PARTY_INVALID_DATE(400, -9001, "해당 날짜는 팟의 인증 기간이 아닙니다."),
-    CONFIRM_IMAGE_NOT_FOUND(404, -9002, "해당 회원의 인증 이미지를 찾을 수 없습니다."),
+    PARTY_NOT_FOUND(404, -11000, "해당 팟을 팢을 수 없습니다."),
+    PARTY_INVALID_DATE(400, -11001, "해당 날짜는 팟의 인증 기간이 아닙니다."),
+    CONFIRM_NOT_FOUND(404, -11002, "해당 회원의 인증을 찾을 수 없습니다."),
 
     //TIMER
     TIMER_NOT_EXIST(404, -12000, "저장된 타이머가 없습니다.")

--- a/src/main/java/com/api/stuv/global/exception/ErrorCode.java
+++ b/src/main/java/com/api/stuv/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(400, -1006, "아이디 또는 비밀번호가 올바르지 않습니다."),
     USER_NOT_FOUND(404, -1007, "존재하지 않는 사용자입니다."),
     DATA_ACCESS_API(401, -1008, "데이터를 받아오지 못했습니다"),
+    QUEST_ALREADY_REWARD(400, -1009, "보상을 이미 받았습니다."),
 
     // TOKEN
     EMPTY_JWT_TOKEN(400, -2000, "JWT 토큰이 없습니다."),

--- a/src/main/java/com/api/stuv/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/api/stuv/global/exception/GlobalExceptionHandler.java
@@ -33,7 +33,7 @@ public class GlobalExceptionHandler {
         String requiredType = requiredTypeClass.getSimpleName();
         String errorMessage = String.format("%s (파라미터명: %s, 요구 타입: %s)",
                 errorCode.getMessage(), paramName, requiredType);
-        log.error("[ERROR] methodArgumentTypeMismatchException - {}", e.getMessage());
+        log.error("[ERROR] handleMethodArgumentTypeMismatchException - {}", e.getMessage());
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.error(errorMessage));
@@ -43,12 +43,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DateTimeParseException.class)
     public ResponseEntity<ApiResponse<Void>> handleDateTimeParseException(DateTimeParseException e) {
         ErrorCode errorCode = ErrorCode.DATE_FORMAT_MISMATCH;
-        log.error("[ERROR] dateTimeParseException - {}", e.getMessage());
+        log.error("[ERROR] handleDateTimeParseException - {}", e.getMessage());
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.error(errorCode.getMessage()));
     }
-
 
     @ExceptionHandler(ExpressionException.class)
     protected ResponseEntity<ApiResponse<Void>> handleExpressionException(ExpressionException e) {

--- a/src/main/java/com/api/stuv/global/exception/ValidationException.java
+++ b/src/main/java/com/api/stuv/global/exception/ValidationException.java
@@ -1,0 +1,10 @@
+package com.api.stuv.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ValidationException extends BusinessException {
+    public ValidationException() {
+        super(ErrorCode.INVALID_ARGUMENT_METHOD);
+    }
+}


### PR DESCRIPTION
## 📌 작업 설명
- 회원의 날짜별 팟 인증에 대한 상태 변경 기능 구현

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #110 

## 🧑‍💻 요구 사항과 구현 내용
- 회원의 날짜별 팟 인증에 대한 상태 변경 기능 구현
- 회원의 팟 퀘스트 성공 여부 체크
- 팟의 인증 완료 여부 체크

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
