### PR TITLE
[#162] 채팅방 목록 및 페이징 응답 수정

### DIFF
--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
@@ -15,4 +15,5 @@ public interface PartyGroupRepositoryCustom {
     PageResponse<AdminPartyGroupResponse> findAllPartyGroupsWithApproved(Pageable pageable);
     AdminPartyAuthDetailResponse findPartyGroupById(Long partyId);
     void updatePartyStatusForPartyGroup(Long partyId, PartyStatus partyStatus);
+    String findPartyGroupNameByUserId(Long userId);
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
@@ -125,4 +125,13 @@ public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
                 .where(pg.id.eq(partyId))
                 .execute();
     }
+
+    @Override
+    public String findPartyGroupNameByUserId(Long userId) {
+        return factory.select(pg.name)
+                .from(gm)
+                .join(pg).on(gm.groupId.eq(pg.id))
+                .where(gm.userId.eq(userId))
+                .fetchFirst();
+    }
 }

--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -23,22 +23,9 @@ public class ChatController {
     private final ChatMessageService chatMessageService;
     private final ChatRoomDetailService chatRoomDetailService;
 
-    @Operation(summary = "채팅방 목록 API", description = "user가 포함된 채팅방 목록을 가져옵니다.")
-    @GetMapping("/{senderId}")
-    public ResponseEntity<ApiResponse<List<String>>> getRoomsBySenderId(
-            @PathVariable Long senderId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-//        List<ChatRoomResponse> roomList = chatRoomDetailService.getSortedRoomListBySenderId(senderId, PageRequest.of(page, size));
-
-        return ResponseEntity.ok()
-                .body(ApiResponse.success((chatRoomDetailService.getRoomIdsBySenderId(
-                        senderId, PageRequest.of(page, size)))));
-//        return ResponseEntity.ok(ApiResponse.success(roomList));
-    }
-
-    @GetMapping("/test/{senderId}")
-    public ResponseEntity<ApiResponse<List<ChatRoomResponse>>> getRoomsBySenderId_test(
+    @Operation(summary = "채팅방 목록 리스트 API", description = "user가 포함된 채팅방 목록을 가져옵니다.")
+    @GetMapping("/list/{senderId}")
+    public ResponseEntity<ApiResponse<List<ChatRoomResponse>>> getRoomListBySenderId(
             @PathVariable Long senderId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {

--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -26,10 +26,8 @@ public class ChatController {
     @Operation(summary = "채팅방 목록 리스트 API", description = "user가 포함된 채팅방 목록을 가져옵니다.")
     @GetMapping("/list/{senderId}")
     public ResponseEntity<ApiResponse<List<ChatRoomResponse>>> getRoomListBySenderId(
-            @PathVariable Long senderId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        List<ChatRoomResponse> roomList = chatRoomDetailService.getSortedRoomListBySenderId(senderId, PageRequest.of(page, size));
+            @PathVariable Long senderId) {
+        List<ChatRoomResponse> roomList = chatRoomDetailService.getSortedRoomListBySenderId(senderId);
 
         return ResponseEntity.ok(ApiResponse.success(roomList));
     }

--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -1,7 +1,9 @@
 package com.api.stuv.domain.socket.controller;
 
 import com.api.stuv.domain.socket.dto.ChatMessageResponse;
+import com.api.stuv.domain.socket.dto.ChatRoomResponse;
 import com.api.stuv.domain.socket.service.ChatMessageService;
+import com.api.stuv.domain.socket.service.ChatRoomDetailService;
 import com.api.stuv.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,12 +21,30 @@ import java.util.List;
 @Tag(name = "ChatRoom", description = "채팅방 관련 API")
 public class ChatController {
     private final ChatMessageService chatMessageService;
+    private final ChatRoomDetailService chatRoomDetailService;
 
     @Operation(summary = "채팅방 목록 API", description = "user가 포함된 채팅방 목록을 가져옵니다.")
     @GetMapping("/{senderId}")
-    public ResponseEntity<ApiResponse<List<String>>> getRoomsBySenderId(@PathVariable Long senderId) {
+    public ResponseEntity<ApiResponse<List<String>>> getRoomsBySenderId(
+            @PathVariable Long senderId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+//        List<ChatRoomResponse> roomList = chatRoomDetailService.getSortedRoomListBySenderId(senderId, PageRequest.of(page, size));
+
         return ResponseEntity.ok()
-                .body(ApiResponse.success((chatMessageService.getRoomIdsBySenderId(senderId))));
+                .body(ApiResponse.success((chatRoomDetailService.getRoomIdsBySenderId(
+                        senderId, PageRequest.of(page, size)))));
+//        return ResponseEntity.ok(ApiResponse.success(roomList));
+    }
+
+    @GetMapping("/test/{senderId}")
+    public ResponseEntity<ApiResponse<List<ChatRoomResponse>>> getRoomsBySenderId_test(
+            @PathVariable Long senderId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        List<ChatRoomResponse> roomList = chatRoomDetailService.getSortedRoomListBySenderId(senderId, PageRequest.of(page, size));
+
+        return ResponseEntity.ok(ApiResponse.success(roomList));
     }
 
     @Operation(summary = "메세지 요청 API", description = "채팅방 메세지를 요청을 합니다.")
@@ -38,4 +58,6 @@ public class ChatController {
                 .body(ApiResponse.success(chatMessageService.getMessagesByRoomIdPagination(
                 roomId, PageRequest.of(page, size))));
     }
+
+
 }

--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatMessageController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatMessageController.java
@@ -95,8 +95,7 @@ public class ChatMessageController {
         logger.info("현재 목록 페이지 구독자: {}", listPageSubscribers);
 
         List<ChatRoomResponse> roomList = chatRoomDetailService.getSortedRoomListBySenderId(
-                readMessageRequest.userId(),
-                PageRequest.of(0, 10)
+                readMessageRequest.userId()
         );
         messagingTemplate.convertAndSend("/topic/rooms/" + userId, ApiResponse.success(roomList));
     }
@@ -135,8 +134,7 @@ public class ChatMessageController {
             // 채팅 목록 페이지에 있는 모든 사용자에게 업데이트 전송
             for (Long subscriberId : listPageSubscribers) {
                 List<ChatRoomResponse> roomList = chatRoomDetailService.getSortedRoomListBySenderId(
-                        subscriberId,
-                        PageRequest.of(0, 10)
+                        subscriberId
                 );
                 messagingTemplate.convertAndSend("/topic/rooms/" + subscriberId, ApiResponse.success(roomList));
             }

--- a/src/main/java/com/api/stuv/domain/socket/dto/ChatMessageResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ChatMessageResponse.java
@@ -1,13 +1,10 @@
 package com.api.stuv.domain.socket.dto;
 
 import com.api.stuv.domain.socket.entity.ChatMessage;
-import com.fasterxml.jackson.annotation.JsonFormat;
-
-import java.time.LocalDateTime;
 import java.util.List;
 
 public record ChatMessageResponse(
-        String id,
+        String chatId,
         String roomId,
         Long senderId,
         String message,

--- a/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
@@ -1,0 +1,30 @@
+package com.api.stuv.domain.socket.dto;
+
+import com.api.stuv.domain.socket.entity.ChatMessage;
+import com.api.stuv.domain.socket.entity.ChatRoom;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomResponse(
+        String roomId,
+        String roomType,
+        String roomName,    // 그룹 채팅이면 방 이름 저장
+        Long lastSenderId,  // 1:1 채팅이면 마지막 메시지 보낸 사람 ID 저장
+        String lastMessage,
+        LocalDateTime createdAt,
+        String profileImageUrl  // ✅ 1:1 채팅일 경우 마지막 메시지 보낸 사람의 프로필 이미지 URL 추가
+) {
+    public static ChatRoomResponse from(ChatRoom room, ChatMessage latestMessage, String profileImageUrl) {
+        boolean isPrivate = "PRIVATE".equals(room.getRoomType());
+
+        return new ChatRoomResponse(
+                room.getRoomId(),
+                room.getRoomType(),
+                isPrivate ? null : room.getRoomName(),  // ✅ 그룹이면 방 이름 설정, private이면 null
+                isPrivate ? (latestMessage != null ? latestMessage.getSenderId() : null) : null,  // ✅ 1:1이면 마지막 보낸 사람 ID 저장
+                latestMessage != null ? latestMessage.getMessage() : "대화 내역 없음",
+                latestMessage != null ? latestMessage.getCreatedAt() : LocalDateTime.MIN,
+                isPrivate ? profileImageUrl : null // ✅ private이면 마지막 보낸 사람의 프로필 URL, 그룹이면 null 반환
+        );
+    }
+}

--- a/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
@@ -8,23 +8,26 @@ import java.time.LocalDateTime;
 public record ChatRoomResponse(
         String roomId,
         String roomType,
-        String roomName,    // 그룹 채팅이면 방 이름 저장
-        Long lastSenderId,  // 1:1 채팅이면 마지막 메시지 보낸 사람 ID 저장
+        String roomName,
+        Long lastSenderId,
         String lastMessage,
         LocalDateTime createdAt,
-        String profileImageUrl  // ✅ 1:1 채팅일 경우 마지막 메시지 보낸 사람의 프로필 이미지 URL 추가
+        String profileImageUrl,
+        String groupName
 ) {
-    public static ChatRoomResponse from(ChatRoom room, ChatMessage latestMessage, String profileImageUrl) {
+    public static ChatRoomResponse from(ChatRoom room, ChatMessage latestMessage, String profileImageUrl, String groupName) {
         boolean isPrivate = "PRIVATE".equals(room.getRoomType());
 
         return new ChatRoomResponse(
                 room.getRoomId(),
                 room.getRoomType(),
-                isPrivate ? null : room.getRoomName(),  // ✅ 그룹이면 방 이름 설정, private이면 null
-                isPrivate ? (latestMessage != null ? latestMessage.getSenderId() : null) : null,  // ✅ 1:1이면 마지막 보낸 사람 ID 저장
+                isPrivate ? null : groupName,
+                isPrivate ? (latestMessage != null ? latestMessage.getSenderId() : null) : null,
                 latestMessage != null ? latestMessage.getMessage() : "대화 내역 없음",
                 latestMessage != null ? latestMessage.getCreatedAt() : LocalDateTime.MIN,
-                isPrivate ? profileImageUrl : null // ✅ private이면 마지막 보낸 사람의 프로필 URL, 그룹이면 null 반환
+                isPrivate ? profileImageUrl : null,
+                isPrivate ? null : groupName
         );
     }
 }
+

--- a/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
@@ -13,9 +13,10 @@ public record ChatRoomResponse(
         String lastMessage,
         LocalDateTime createdAt,
         String profileImageUrl,
-        String groupName
+        String groupName,
+        int unreadCount
 ) {
-    public static ChatRoomResponse from(ChatRoom room, ChatMessage latestMessage, String profileImageUrl, String groupName) {
+    public static ChatRoomResponse from(ChatRoom room, ChatMessage latestMessage, String profileImageUrl, String groupName, int unreadCount) {
         boolean isPrivate = "PRIVATE".equals(room.getRoomType());
 
         return new ChatRoomResponse(
@@ -26,7 +27,8 @@ public record ChatRoomResponse(
                 latestMessage != null ? latestMessage.getMessage() : "대화 내역 없음",
                 latestMessage != null ? latestMessage.getCreatedAt() : LocalDateTime.MIN,
                 isPrivate ? profileImageUrl : null,
-                isPrivate ? null : groupName
+                isPrivate ? null : groupName,
+                unreadCount
         );
     }
 }

--- a/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
@@ -12,11 +12,11 @@ public record ChatRoomResponse(
         Long lastSenderId,
         String lastMessage,
         LocalDateTime createdAt,
-        String profileImageUrl,
+        String profile,
         String groupName,
         int unreadCount
 ) {
-    public static ChatRoomResponse from(ChatRoom room, ChatMessage latestMessage, String profileImageUrl, String groupName, int unreadCount) {
+    public static ChatRoomResponse from(ChatRoom room, ChatMessage latestMessage, String profile, String groupName, int unreadCount) {
         boolean isPrivate = "PRIVATE".equals(room.getRoomType());
 
         return new ChatRoomResponse(
@@ -26,7 +26,7 @@ public record ChatRoomResponse(
                 isPrivate ? (latestMessage != null ? latestMessage.getSenderId() : null) : null,
                 latestMessage != null ? latestMessage.getMessage() : "대화 내역 없음",
                 latestMessage != null ? latestMessage.getCreatedAt() : LocalDateTime.MIN,
-                isPrivate ? profileImageUrl : null,
+                isPrivate ? profile : null,
                 isPrivate ? null : groupName,
                 unreadCount
         );

--- a/src/main/java/com/api/stuv/domain/socket/dto/ReadByResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ReadByResponse.java
@@ -5,8 +5,8 @@ import com.api.stuv.domain.socket.entity.ChatMessage;
 import java.util.List;
 
 public record ReadByResponse(
-        String id,
-        String room_id,
+        String chatId,
+        String roomId,
         Integer readByCount
 ) {
     public static ReadByResponse from(ChatMessage chatMessage) {

--- a/src/main/java/com/api/stuv/domain/socket/entity/ChatMessage.java
+++ b/src/main/java/com/api/stuv/domain/socket/entity/ChatMessage.java
@@ -35,7 +35,7 @@ public class ChatMessage {
     private String message;
 
     @Field("read_by")
-    @Builder.Default
+//    @Builder.Default
     private List<Long> readBy = new ArrayList<>();
 
     @Field("created_at")

--- a/src/main/java/com/api/stuv/domain/socket/entity/ChatMessage.java
+++ b/src/main/java/com/api/stuv/domain/socket/entity/ChatMessage.java
@@ -35,7 +35,7 @@ public class ChatMessage {
     private String message;
 
     @Field("read_by")
-//    @Builder.Default
+    @Builder.Default
     private List<Long> readBy = new ArrayList<>();
 
     @Field("created_at")

--- a/src/main/java/com/api/stuv/domain/socket/entity/ChatRoom.java
+++ b/src/main/java/com/api/stuv/domain/socket/entity/ChatRoom.java
@@ -30,6 +30,9 @@ public class ChatRoom {
     @Field("room_type")
     private String roomType;
 
+    @Field("room_name")
+    private String roomName;
+
     @Field("members")
     private List<Long> members;
 

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepository.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepository.java
@@ -14,4 +14,5 @@ import java.util.List;
 @Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String>, ChatMessageRepositoryCustom {
     Page<ChatMessage> findByRoomIdOrderByCreatedAtDesc(String roomId, Pageable pageable);
+    ChatMessage findTopByRoomIdOrderByCreatedAtDesc(String roomId);
 }

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryCustom.java
@@ -2,4 +2,6 @@ package com.api.stuv.domain.socket.repository;
 
 public interface ChatMessageRepositoryCustom {
     void updateManyReadBy(String roomId, Long userId);
+    int countUnreadMessages(String roomId, Long userId);
+
 }

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryImpl.java
@@ -2,10 +2,17 @@ package com.api.stuv.domain.socket.repository;
 
 import com.api.stuv.domain.socket.entity.ChatMessage;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.util.CloseableIterator;
 import org.springframework.stereotype.Repository;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
@@ -24,5 +31,26 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
         Update update = new Update().addToSet("read_by", userId); // read_by 배열에 userId 추가
 
         mongoTemplate.updateMulti(query, update, ChatMessage.class); // 여러 개의 메시지 업데이트
+    }
+
+    @Override
+    public int countUnreadMessages(String roomId, Long userId) {
+        Query query = new Query()
+                .addCriteria(Criteria.where("room_id").is(roomId))
+                .with(Sort.by(Sort.Direction.DESC, "created_at"))
+                .limit(100);
+
+        int unreadCount = 0;
+        try (Stream<ChatMessage> stream = mongoTemplate.stream(query, ChatMessage.class)) {
+            Iterator<ChatMessage> iterator = stream.iterator();
+            while (iterator.hasNext()) {
+                ChatMessage message = iterator.next();
+                if (message.getReadBy().contains(userId)) {
+                    break;
+                }
+                unreadCount++;
+            }
+        }
+        return unreadCount;
     }
 }

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatRoomRepository.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatRoomRepository.java
@@ -1,6 +1,8 @@
 package com.api.stuv.domain.socket.repository;
 
 import com.api.stuv.domain.socket.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +12,5 @@ import java.util.Optional;
 @Repository
 public interface ChatRoomRepository extends MongoRepository<ChatRoom, String>{
     Optional<ChatRoom> findByRoomId(String roomId);
-    List<ChatRoom> findByMembersContaining(Long userId);
+    Page<ChatRoom> findByMembersContaining(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatRoomRepository.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatRoomRepository.java
@@ -12,5 +12,5 @@ import java.util.Optional;
 @Repository
 public interface ChatRoomRepository extends MongoRepository<ChatRoom, String>{
     Optional<ChatRoom> findByRoomId(String roomId);
-    Page<ChatRoom> findByMembersContaining(Long userId, Pageable pageable);
+    List<ChatRoom> findByMembersContaining(Long userId);
 }

--- a/src/main/java/com/api/stuv/domain/socket/service/ChatMessageService.java
+++ b/src/main/java/com/api/stuv/domain/socket/service/ChatMessageService.java
@@ -4,7 +4,6 @@ import com.api.stuv.domain.socket.dto.ChatMessageRequest;
 import com.api.stuv.domain.socket.dto.ChatMessageResponse;
 import com.api.stuv.domain.socket.dto.ReadByResponse;
 import com.api.stuv.domain.socket.entity.ChatMessage;
-import com.api.stuv.domain.socket.entity.ChatRoom;
 import com.api.stuv.domain.socket.repository.ChatMessageRepository;
 import com.api.stuv.domain.socket.repository.ChatRoomRepository;
 import com.api.stuv.global.exception.ErrorCode;
@@ -17,7 +16,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,22 +25,6 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberService chatRoomMemberService; // 총 멤버 정보를 관리하는 서비스
 
-
-    // 특정 senderId가 포함된 채팅방의 roomId 목록 조회
-    public List<String> getRoomIdsBySenderId(Long senderId) {
-        List<String> roomIds = chatRoomRepository.findByMembersContaining(senderId)
-                .stream()
-                .map(ChatRoom::getRoomId)
-                .distinct()
-                .collect(Collectors.toList());
-
-        if (roomIds.isEmpty()) {
-            throw new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND);
-        }
-
-        return roomIds;
-    }
-    
     //메세지 불러오기
     public List<ChatMessageResponse> getMessagesByRoomIdPagination(String roomId, Pageable pageable) {
 

--- a/src/main/java/com/api/stuv/domain/socket/service/ChatMessageService.java
+++ b/src/main/java/com/api/stuv/domain/socket/service/ChatMessageService.java
@@ -88,7 +88,7 @@ public class ChatMessageService {
         ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
         int unreadCount = chatRoomMemberService.getRoomMemberCount(request.roomId()) - response.readByCount();
         return new ChatMessageResponse(
-                response.id(),
+                response.chatId(),
                 response.roomId(),
                 response.senderId(),
                 response.message(),
@@ -112,8 +112,8 @@ public class ChatMessageService {
                 .stream()
                 .map(ReadByResponse::from)
                 .map(r -> new ReadByResponse(
-                        r.id(),
-                        r.room_id(),
+                        r.chatId(),
+                        r.roomId(),
                         totalMembers - r.readByCount() // unreadCount 계산
                 ))
                 .collect(Collectors.toList());

--- a/src/main/java/com/api/stuv/domain/socket/service/ChatRoomDetailService.java
+++ b/src/main/java/com/api/stuv/domain/socket/service/ChatRoomDetailService.java
@@ -1,0 +1,66 @@
+package com.api.stuv.domain.socket.service;
+
+import com.api.stuv.domain.socket.dto.ChatRoomResponse;
+import com.api.stuv.domain.socket.entity.ChatMessage;
+import com.api.stuv.domain.socket.entity.ChatRoom;
+import com.api.stuv.domain.socket.repository.ChatMessageRepository;
+import com.api.stuv.domain.socket.repository.ChatRoomRepository;
+import com.api.stuv.domain.user.repository.UserRepository;
+import com.api.stuv.global.exception.ErrorCode;
+import com.api.stuv.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.AbstractMap;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomDetailService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+
+    // 특정 senderId가 포함된 채팅방의 roomId 목록 조회
+    public List<String> getRoomIdsBySenderId(Long senderId, Pageable pageable) {
+        Page<ChatRoom> chatRooms = chatRoomRepository.findByMembersContaining(senderId, pageable);
+
+        if (chatRooms.isEmpty()) {
+            throw new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND);
+        }
+
+        return chatRooms.getContent()
+                .stream()
+                .map(ChatRoom::getRoomId)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    public List<ChatRoomResponse> getSortedRoomListBySenderId(Long senderId, Pageable pageable) {
+        Page<ChatRoom> chatRooms = chatRoomRepository.findByMembersContaining(senderId, pageable);
+
+        if (chatRooms.isEmpty()) {
+            throw new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND);
+        }
+
+        return chatRooms.getContent()
+                .stream()
+                .map(room -> {
+                    ChatMessage latestMessage = chatMessageRepository.findTopByRoomIdOrderByCreatedAtDesc(room.getRoomId());
+
+                    String profileImageUrl = null;
+                    if ("PRIVATE".equals(room.getRoomType()) && latestMessage != null) {
+                        profileImageUrl = userRepository.getCostumeInfoByUserId(latestMessage.getSenderId());
+                    }
+
+                    return ChatRoomResponse.from(room, latestMessage, profileImageUrl);
+                })
+                .sorted(Comparator.comparing(ChatRoomResponse::createdAt, Comparator.reverseOrder())) // 최신 메시지 기준 내림차순 정렬
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
@@ -1,9 +1,6 @@
 package com.api.stuv.domain.user.repository;
 
-import com.api.stuv.domain.user.dto.response.GetCostume;
-import com.api.stuv.domain.user.dto.response.UserBoardListResponse;
-import com.api.stuv.domain.user.dto.response.UserInformationResponse;
-import com.api.stuv.domain.user.dto.response.MyInformationResponse;
+import com.api.stuv.domain.user.dto.response.*;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -13,4 +10,5 @@ public interface UserRepositoryCustom {
     MyInformationResponse getUserByMyId(@Param("myId") Long myId);
     List<UserBoardListResponse> getUserBoardList(@Param("userId") Long userId);
     List<GetCostume> getUserCostume(@Param("userId") Long userId);
+    String getCostumeInfoByUserId(Long userId);
 }

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryImpl.java
@@ -145,21 +145,24 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
 
     @Override
     public String getCostumeInfoByUserId(Long userId) {
-        String filename = jpaQueryFactory
-                .select(i.newFilename)
+        Tuple costumeDetails = jpaQueryFactory
+                .select(i.entityId, i.newFilename)
                 .from(u)
                 .leftJoin(uc).on(u.costumeId.eq(uc.id))
                 .leftJoin(i).on(uc.costumeId.eq(i.entityId).and(i.entityType.eq(EntityType.COSTUME)))
                 .where(u.id.eq(userId))
                 .fetchFirst();
 
-        if (filename == null) {
+        if (costumeDetails == null || costumeDetails.get(i.newFilename) == null) {
             return null;
         }
 
+        Long entityId = costumeDetails.get(i.entityId);
+        String filename = costumeDetails.get(i.newFilename);
+
         return s3ImageService.generateImageFile(
                 EntityType.COSTUME,
-                null,
+                entityId,
                 filename
         );
     }

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryImpl.java
@@ -5,10 +5,7 @@ import com.api.stuv.domain.friend.entity.QFriend;
 import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.entity.QImageFile;
 import com.api.stuv.domain.image.service.S3ImageService;
-import com.api.stuv.domain.user.dto.response.GetCostume;
-import com.api.stuv.domain.user.dto.response.UserBoardListResponse;
-import com.api.stuv.domain.user.dto.response.UserInformationResponse;
-import com.api.stuv.domain.user.dto.response.MyInformationResponse;
+import com.api.stuv.domain.user.dto.response.*;
 import com.api.stuv.domain.user.entity.QUser;
 import com.api.stuv.domain.user.entity.QUserCostume;
 import com.api.stuv.global.exception.ErrorCode;
@@ -145,4 +142,26 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
 
         return query;
     }
+
+    @Override
+    public String getCostumeInfoByUserId(Long userId) {
+        String filename = jpaQueryFactory
+                .select(i.newFilename)
+                .from(u)
+                .leftJoin(uc).on(u.costumeId.eq(uc.id))
+                .leftJoin(i).on(uc.costumeId.eq(i.entityId).and(i.entityType.eq(EntityType.COSTUME)))
+                .where(u.id.eq(userId))
+                .fetchFirst();
+
+        if (filename == null) {
+            return null;
+        }
+
+        return s3ImageService.generateImageFile(
+                EntityType.COSTUME,
+                null,
+                filename
+        );
+    }
+
 }


### PR DESCRIPTION
## 📌 작업 설명
- 채팅방 목록 및 페이징 응답 수정

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #162 

## 🧑‍💻 요구 사항과 구현 내용
- `ChatMessageService`에서 `ChatRoomDetailService`로 채팅방 조회 서비스 이동  
- 각 채팅방의 마지막 메시지와 전송 시간을 함께 반환  
- 최신 메시지를 기준으로 채팅방 목록 정렬  
- PRIVATE - 마지막 메시지 보낸 사용자의 프로필 이미지 및 닉네임 추가  
- GROUP - 그룹명과 마지막 메시지 반환  
- 사용자가 읽지 않은 메시지 개수(`unreadCount`) 표시  
- 새 메시지가 전송될 때마다 웹소켓 실시간으로 채팅 목록 업데이트  
- 구독자 체크 - 채팅 목록 페이지에 접속한 사용자가 없는 경우 불필요한 서비스를 실행하지 않음  

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
