### PR TITLE
[#229] 팟 상세 정보 조회 (자신의 참가여부 포함) 기능

### DIFF
--- a/src/main/java/com/api/stuv/domain/party/controller/PartyController.java
+++ b/src/main/java/com/api/stuv/domain/party/controller/PartyController.java
@@ -1,6 +1,7 @@
 package com.api.stuv.domain.party.controller;
 
 import com.api.stuv.domain.auth.util.TokenUtil;
+import com.api.stuv.domain.party.dto.response.PartyDetailResponse;
 import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
 import com.api.stuv.domain.party.dto.response.PartyRewardStatusResponse;
 import com.api.stuv.domain.party.service.PartyService;
@@ -11,10 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -55,6 +53,15 @@ public class PartyController {
         return ResponseEntity.ok()
                 .body(ApiResponse.success(
                         partyService.getCompletePartyStatus(tokenUtil.getUserId())
+                ));
+    }
+
+    @GetMapping("/{partyId}")
+    @Operation(summary = "팟 상세 조회 API", description = "팟의 상세한 내용과 현재 회원의 참가 여부를 조회합니다.")
+    public ResponseEntity<ApiResponse<PartyDetailResponse>> getPartyDetail(@PathVariable Long partyId) {
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(
+                        partyService.getPartyDetailInfo(partyId, tokenUtil.getUserId())
                 ));
     }
 }

--- a/src/main/java/com/api/stuv/domain/party/dto/response/PartyDetailResponse.java
+++ b/src/main/java/com/api/stuv/domain/party/dto/response/PartyDetailResponse.java
@@ -1,0 +1,16 @@
+package com.api.stuv.domain.party.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record PartyDetailResponse(
+        Long partyId,
+        String name,
+        Long recruitCap,
+        Long recruitCnt,
+        LocalDate startDate,
+        LocalDate endDate,
+        BigDecimal bettingPointCap,
+        boolean isJoined
+) {
+}

--- a/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.api.stuv.domain.party.repository.member;
 import com.api.stuv.domain.admin.dto.MemberDetailDTO;
 import com.api.stuv.domain.party.entity.QuestStatus;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -10,4 +11,7 @@ public interface GroupMemberRepositoryCustom {
     List<MemberDetailDTO> findMemberListWithConfirmedByDate(Long partyId, LocalDate date);
     void updateQuestStatusForMember(Long partyId, Long memberId, QuestStatus questStatus);
     boolean isMemberNotProgressByGroupId(Long partyId);
+    BigDecimal sumFailedGroupMemberBettingPoint(Long partyId);
+    Long countSuccessGroupMembers(Long partyId);
+    Long countAllGroupMembers(Long partyId);
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.api.stuv.domain.admin.dto.MemberDetailDTO;
 import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.entity.QImageFile;
 import com.api.stuv.domain.image.service.S3ImageService;
-import com.api.stuv.domain.party.entity.GroupMember;
 import com.api.stuv.domain.party.entity.QGroupMember;
 import com.api.stuv.domain.party.entity.QQuestConfirm;
 import com.api.stuv.domain.party.entity.QuestStatus;
@@ -13,6 +12,7 @@ import com.api.stuv.domain.user.entity.QUserCostume;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -73,5 +73,34 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                                 .and(gm.questStatus.eq(QuestStatus.PROGRESS)))
                         .fetchOne()
         ).orElse(0L) == 0;
+    }
+
+    @Override
+    public Long countAllGroupMembers(Long partyId) {
+        return factory
+                .select(gm.id.count())
+                .from(gm)
+                .where(gm.groupId.eq(partyId))
+                .fetchOne();
+    }
+
+    @Override
+    public BigDecimal sumFailedGroupMemberBettingPoint(Long partyId) {
+        return factory
+                .select(gm.bettingPoint.sum().coalesce(BigDecimal.ZERO))
+                .from(gm)
+                .where(gm.groupId.eq(partyId)
+                        .and(gm.questStatus.eq(QuestStatus.FAILED)))
+                .fetchOne();
+    }
+
+    @Override
+    public Long countSuccessGroupMembers(Long partyId) {
+        return factory
+                .select(gm.id.count().coalesce(0L))
+                .from(gm)
+                .where(gm.groupId.eq(partyId)
+                        .and(gm.questStatus.in(QuestStatus.SUCCESS, QuestStatus.COMPLETED)))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.api.stuv.domain.party.repository.party;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
 import com.api.stuv.domain.admin.dto.response.AdminPartyGroupResponse;
 import com.api.stuv.domain.party.dto.MemberRewardStatusDTO;
+import com.api.stuv.domain.party.dto.response.PartyDetailResponse;
 import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
 import com.api.stuv.domain.party.entity.PartyStatus;
 import com.api.stuv.global.response.PageResponse;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 public interface PartyGroupRepositoryCustom {
     PageResponse<PartyGroupResponse> findPendingGroupsByName(String name, Pageable pageable);
@@ -18,8 +20,6 @@ public interface PartyGroupRepositoryCustom {
     AdminPartyAuthDetailResponse findPartyGroupById(Long partyId);
     void updatePartyStatusForPartyGroup(Long partyId, PartyStatus partyStatus);
     String findPartyGroupNameByUserId(Long userId);
-    List<MemberRewardStatusDTO> findCompletePartuStatusList(Long userId);
-    BigDecimal sumFailedGroupMemberBettingPoint(Long partyId);
-    Long countSuccessGroupMembers(Long partyId);
-    Long countAllGroupMembers(Long partyId);
+    List<MemberRewardStatusDTO> findCompletePartyStatusList(Long userId);
+    Optional<PartyDetailResponse> findDetailByUserId(Long partyId, Long userId);
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
@@ -3,8 +3,11 @@ package com.api.stuv.domain.party.repository.party;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
 import com.api.stuv.domain.admin.dto.response.AdminPartyGroupResponse;
 import com.api.stuv.domain.party.dto.MemberRewardStatusDTO;
+import com.api.stuv.domain.party.dto.response.PartyDetailResponse;
 import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
 import com.api.stuv.domain.party.entity.*;
+import com.api.stuv.global.exception.ErrorCode;
+import com.api.stuv.global.exception.NotFoundException;
 import com.api.stuv.global.response.PageResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -17,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
@@ -133,7 +137,7 @@ public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
     }
 
     @Override
-    public List<MemberRewardStatusDTO> findCompletePartuStatusList(Long userId) {
+    public List<MemberRewardStatusDTO> findCompletePartyStatusList(Long userId) {
         return factory
                 .select(Projections.constructor(
                         MemberRewardStatusDTO.class,
@@ -150,32 +154,30 @@ public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
     }
 
     @Override
-    public Long countAllGroupMembers(Long partyId) {
-        return factory
-                .select(pg.id.count())
-                .from(pg)
-                .leftJoin(gm).on(pg.id.eq(gm.groupId))
-                .where(pg.id.eq(partyId))
-                .fetchOne();
-    }
-
-    @Override
-    public BigDecimal sumFailedGroupMemberBettingPoint(Long partyId) {
-        return factory
-                .select(gm.bettingPoint.sum().coalesce(BigDecimal.ZERO))
-                .from(gm)
-                .where(gm.groupId.eq(partyId)
-                        .and(gm.questStatus.eq(QuestStatus.FAILED)))
-                .fetchOne();
-    }
-
-    @Override
-    public Long countSuccessGroupMembers(Long partyId) {
-        return factory
-                .select(gm.id.count().coalesce(0L))
-                .from(gm)
-                .where(gm.groupId.eq(partyId)
-                        .and(gm.questStatus.in(QuestStatus.SUCCESS, QuestStatus.COMPLETED)))
-                .fetchOne();
+    public Optional<PartyDetailResponse> findDetailByUserId(Long partyId, Long userId) {
+        return Optional.ofNullable(
+                factory
+                        .select(Projections.constructor(
+                                PartyDetailResponse.class,
+                                pg.id,
+                                pg.name,
+                                pg.recruitCap,
+                                gm.id.count(),
+                                pg.startDate,
+                                pg.endDate,
+                                pg.bettingPoint,
+                                factory
+                                        .selectOne()
+                                        .from(gm)
+                                        .where(gm.groupId.eq(partyId)
+                                                .and(gm.userId.eq(userId)))
+                                        .exists()
+                        ))
+                        .from(pg)
+                        .leftJoin(gm).on(pg.id.eq(gm.groupId))
+                        .where(pg.id.eq(partyId))
+                        .groupBy(pg.id, pg.name, pg.recruitCap, pg.startDate, pg.endDate, pg.bettingPoint)
+                        .fetchOne()
+        );
     }
 }

--- a/src/main/java/com/api/stuv/domain/party/service/PartyService.java
+++ b/src/main/java/com/api/stuv/domain/party/service/PartyService.java
@@ -1,8 +1,10 @@
 package com.api.stuv.domain.party.service;
 
+import com.api.stuv.domain.party.dto.response.PartyDetailResponse;
 import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
 import com.api.stuv.domain.party.dto.response.PartyRewardStatusResponse;
 import com.api.stuv.domain.party.entity.QuestStatus;
+import com.api.stuv.domain.party.repository.member.GroupMemberRepository;
 import com.api.stuv.domain.party.repository.party.PartyGroupRepository;
 import com.api.stuv.domain.user.entity.RewardType;
 import com.api.stuv.domain.user.repository.UserRepository;
@@ -24,6 +26,7 @@ public class PartyService {
 
     private final PartyGroupRepository partyRepository;
     private final UserRepository userRepository;
+    private final GroupMemberRepository memberRepository;
 
     public PageResponse<PartyGroupResponse> getPendingPartyGroups(String name, Pageable pageable) {
         return partyRepository.findPendingGroupsByName(name, pageable);
@@ -36,14 +39,14 @@ public class PartyService {
 
     public List<PartyRewardStatusResponse> getCompletePartyStatus(Long userId) {
         if (!userRepository.existsById(userId)) throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
-        return partyRepository.findCompletePartuStatusList(userId).stream().map(dto -> {
-            Long count = partyRepository.countAllGroupMembers(dto.partyId());
+        return partyRepository.findCompletePartyStatusList(userId).stream().map(dto -> {
+            Long count = memberRepository.countAllGroupMembers(dto.partyId());
             BigDecimal reward = Optional.ofNullable(dto.bettingPoint()).orElse(BigDecimal.ZERO);
 
             if (dto.questStatus() != QuestStatus.FAILED) {
-                long successCount = Optional.ofNullable(partyRepository.countSuccessGroupMembers(dto.partyId())).orElse(0L);
+                long successCount = Optional.ofNullable(memberRepository.countSuccessGroupMembers(dto.partyId())).orElse(0L);
 
-                BigDecimal failedBettingSum = Optional.ofNullable(partyRepository.sumFailedGroupMemberBettingPoint(dto.partyId()))
+                BigDecimal failedBettingSum = Optional.ofNullable(memberRepository.sumFailedGroupMemberBettingPoint(dto.partyId()))
                         .orElse(BigDecimal.ZERO);
 
                 BigDecimal serviceSupportPoint = RewardType.PARTY.getValue()
@@ -63,5 +66,10 @@ public class PartyService {
                     dto.questStatus().getText()
             );
         }).toList();
+    }
+
+    public PartyDetailResponse getPartyDetailInfo(Long partyId, Long userId) {
+        return partyRepository.findDetailByUserId(partyId, userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PARTY_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 📌 작업 설명
- 팟 상세 정보 조회 (자신의 참가여부 포함) 기능

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #229 

## 🧑‍💻 요구 사항과 구현 내용
- 팟 상세 정보 조회 (자신의 참가여부 포함) 기능

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
