### PR TITLE
[#243] 팟 참여자 목록 조회 및 이벤트 배너 조회 기능 구현

### DIFF
--- a/src/main/java/com/api/stuv/domain/party/controller/PartyController.java
+++ b/src/main/java/com/api/stuv/domain/party/controller/PartyController.java
@@ -3,10 +3,7 @@ package com.api.stuv.domain.party.controller;
 import com.api.stuv.domain.auth.util.TokenUtil;
 import com.api.stuv.domain.party.dto.request.PartyCreateRequest;
 import com.api.stuv.domain.party.dto.request.PartyJoinRequest;
-import com.api.stuv.domain.party.dto.response.PartyDetailResponse;
-import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
-import com.api.stuv.domain.party.dto.response.PartyIdResponse;
-import com.api.stuv.domain.party.dto.response.PartyRewardStatusResponse;
+import com.api.stuv.domain.party.dto.response.*;
 import com.api.stuv.domain.party.service.PartyService;
 import com.api.stuv.global.response.ApiResponse;
 import com.api.stuv.global.response.PageResponse;
@@ -83,6 +80,15 @@ public class PartyController {
         partyService.joinParty(request.bettingPoint(), partyId, tokenUtil.getUserId());
         return ResponseEntity.ok()
                 .body(ApiResponse.success());
+    }
+
+    @GetMapping("/event")
+    @Operation(summary = "이벤트 배너 조회 API", description = "이벤트 팟의 배너를 조회할 수 있습니다.")
+    public ResponseEntity<ApiResponse<List<EventBannerResponse>>> getEventBanner() {
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(
+                        partyService.getEventList()
+                ));
     }
 }
 

--- a/src/main/java/com/api/stuv/domain/party/controller/PartyController.java
+++ b/src/main/java/com/api/stuv/domain/party/controller/PartyController.java
@@ -1,6 +1,7 @@
 package com.api.stuv.domain.party.controller;
 
 import com.api.stuv.domain.auth.util.TokenUtil;
+import com.api.stuv.domain.party.dto.response.MemberResponse;
 import com.api.stuv.domain.party.dto.request.PartyCreateRequest;
 import com.api.stuv.domain.party.dto.request.PartyJoinRequest;
 import com.api.stuv.domain.party.dto.response.*;
@@ -88,6 +89,19 @@ public class PartyController {
         return ResponseEntity.ok()
                 .body(ApiResponse.success(
                         partyService.getEventList()
+                ));
+    }
+
+    @GetMapping("/{partyId}/users")
+    @Operation(summary = "팟 참가자 목록 조회 API", description = "팟의 참가자 목록을 조회할 수 있습니다.")
+    public ResponseEntity<ApiResponse<PageResponse<MemberResponse>>> getMemberList(
+            @PathVariable Long partyId,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(
+                        partyService.getPartyMemberList(partyId, tokenUtil.getUserId(), PageRequest.of(page, size))
                 ));
     }
 }

--- a/src/main/java/com/api/stuv/domain/party/dto/MemberDTO.java
+++ b/src/main/java/com/api/stuv/domain/party/dto/MemberDTO.java
@@ -1,0 +1,12 @@
+package com.api.stuv.domain.party.dto;
+
+public record MemberDTO(
+        Long friendId,
+        Long userId,
+        String nickname,
+        String context,
+        Long imageId,
+        String image,
+        String status
+) {
+}

--- a/src/main/java/com/api/stuv/domain/party/dto/response/EventBannerResponse.java
+++ b/src/main/java/com/api/stuv/domain/party/dto/response/EventBannerResponse.java
@@ -1,0 +1,7 @@
+package com.api.stuv.domain.party.dto.response;
+
+public record EventBannerResponse(
+        String image,
+        Long partyId
+) {
+}

--- a/src/main/java/com/api/stuv/domain/party/dto/response/MemberResponse.java
+++ b/src/main/java/com/api/stuv/domain/party/dto/response/MemberResponse.java
@@ -1,0 +1,11 @@
+package com.api.stuv.domain.party.dto.response;
+
+public record MemberResponse(
+        Long friendId,
+        Long userId,
+        String nickname,
+        String profile,
+        String context,
+        String status
+) {
+}

--- a/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryCustom.java
@@ -1,7 +1,9 @@
 package com.api.stuv.domain.party.repository.member;
 
 import com.api.stuv.domain.admin.dto.MemberDetailDTO;
+import com.api.stuv.domain.party.dto.MemberDTO;
 import com.api.stuv.domain.party.entity.QuestStatus;
+import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -14,4 +16,5 @@ public interface GroupMemberRepositoryCustom {
     BigDecimal sumFailedGroupMemberBettingPoint(Long partyId);
     Long countSuccessGroupMembers(Long partyId);
     Long countAllGroupMembers(Long partyId);
+    List<MemberDTO> findMemberList(Long partyId, Long userId, Pageable pageable);
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/member/GroupMemberRepositoryImpl.java
@@ -1,16 +1,25 @@
 package com.api.stuv.domain.party.repository.member;
 
 import com.api.stuv.domain.admin.dto.MemberDetailDTO;
+import com.api.stuv.domain.friend.entity.FriendStatus;
+import com.api.stuv.domain.friend.entity.QFriend;
 import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.entity.QImageFile;
 import com.api.stuv.domain.image.service.S3ImageService;
+import com.api.stuv.domain.party.dto.MemberDTO;
 import com.api.stuv.domain.party.entity.QGroupMember;
 import com.api.stuv.domain.party.entity.QQuestConfirm;
 import com.api.stuv.domain.party.entity.QuestStatus;
 import com.api.stuv.domain.user.entity.QUser;
 import com.api.stuv.domain.user.entity.QUserCostume;
+import com.api.stuv.domain.user.entity.UserStatus;
+import com.api.stuv.global.response.PageResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -27,6 +36,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
     private final QUser u = QUser.user;
     private final QUserCostume uc = QUserCostume.userCostume;
     private final QImageFile i = QImageFile.imageFile;
+    private final QFriend f = QFriend.friend;
 
     @Override
     public List<MemberDetailDTO> findMemberListWithConfirmedByDate(Long partyId, LocalDate date) {
@@ -102,5 +112,32 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .where(gm.groupId.eq(partyId)
                         .and(gm.questStatus.in(QuestStatus.SUCCESS, QuestStatus.COMPLETED)))
                 .fetchOne();
+    }
+
+    @Override
+    public List<MemberDTO> findMemberList(Long partyId, Long userId, Pageable pageable) {
+        return factory.select(Projections.constructor(
+                        MemberDTO.class,
+                        f.id,
+                        gm.userId,
+                        u.nickname,
+                        u.context,
+                        i.entityId,
+                        i.newFilename,
+                        Expressions.cases()
+                                .when(f.userId.eq(userId).and(f.status.eq(FriendStatus.PENDING))).then(UserStatus.SENDER.toString())
+                                .when(f.friendId.eq(userId).and(f.status.eq(FriendStatus.PENDING))).then(UserStatus.RECEIVER.toString())
+                                .when(f.status.eq(FriendStatus.ACCEPTED).and(f.userId.eq(userId).or(f.friendId.eq(userId)))).then(UserStatus.FRIEND.toString())
+                                .otherwise(UserStatus.NOT_FRIEND.toString())
+                ))
+                .from(gm)
+                .leftJoin(u).on(gm.userId.eq(u.id))
+                .leftJoin(uc).on(u.costumeId.eq(uc.id))
+                .leftJoin(i).on(uc.costumeId.eq(i.entityId).and(i.entityType.eq(EntityType.COSTUME)))
+                .leftJoin(f).on((f.userId.eq(userId).and(f.friendId.eq(u.id))).or(f.friendId.eq(userId).and(f.userId.eq(u.id))))
+                .where(gm.groupId.eq(partyId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
     }
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.api.stuv.domain.party.repository.party;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
 import com.api.stuv.domain.admin.dto.response.AdminPartyGroupResponse;
 import com.api.stuv.domain.party.dto.MemberRewardStatusDTO;
+import com.api.stuv.domain.party.dto.response.EventBannerResponse;
 import com.api.stuv.domain.party.dto.response.PartyDetailResponse;
 import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
 import com.api.stuv.domain.party.entity.PartyStatus;
@@ -21,4 +22,5 @@ public interface PartyGroupRepositoryCustom {
     void updatePartyStatusForPartyGroup(Long partyId, PartyStatus partyStatus);
     List<MemberRewardStatusDTO> findCompletePartyStatusList(Long userId);
     Optional<PartyDetailResponse> findDetailByUserId(Long partyId, Long userId);
+    List<EventBannerResponse> findEventPartyList();
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
@@ -9,18 +9,14 @@ import com.api.stuv.domain.party.dto.response.EventBannerResponse;
 import com.api.stuv.domain.party.dto.response.PartyDetailResponse;
 import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
 import com.api.stuv.domain.party.entity.*;
-import com.api.stuv.global.exception.ErrorCode;
-import com.api.stuv.global.exception.NotFoundException;
 import com.api.stuv.global.response.PageResponse;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -92,7 +88,7 @@ public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
                         gm.id.count(),
                         pg.startDate,
                         pg.endDate,
-                        new CaseBuilder()
+                        Expressions.cases()
                                 .when(pg.status.eq(PartyStatus.APPROVED)).then(PartyStatus.APPROVED.getText())
                                 .otherwise(PartyStatus.PENDING.getText())))
                 .from(pg)

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
@@ -2,7 +2,10 @@ package com.api.stuv.domain.party.repository.party;
 
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
 import com.api.stuv.domain.admin.dto.response.AdminPartyGroupResponse;
+import com.api.stuv.domain.image.entity.EntityType;
+import com.api.stuv.domain.image.entity.QImageFile;
 import com.api.stuv.domain.party.dto.MemberRewardStatusDTO;
+import com.api.stuv.domain.party.dto.response.EventBannerResponse;
 import com.api.stuv.domain.party.dto.response.PartyDetailResponse;
 import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
 import com.api.stuv.domain.party.entity.*;
@@ -28,6 +31,7 @@ public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
     private final JPAQueryFactory factory;
     private final QPartyGroup pg = QPartyGroup.partyGroup;
     private final QGroupMember gm = QGroupMember.groupMember;
+    private final QImageFile i = QImageFile.imageFile;
 
     @Override
     public PageResponse<PartyGroupResponse> findPendingGroupsByName(String name, Pageable pageable) {
@@ -170,5 +174,22 @@ public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
                         .groupBy(pg.id, pg.name, pg.recruitCap, pg.startDate, pg.endDate, pg.bettingPoint)
                         .fetchOne()
         );
+    }
+
+    @Override
+    public List<EventBannerResponse> findEventPartyList() {
+        LocalDate today = LocalDate.now();
+        return factory
+                .select(Projections.constructor(
+                        EventBannerResponse.class,
+                        i.newFilename,
+                        pg.id
+                ))
+                .from(pg)
+                .leftJoin(i).on(pg.id.eq(i.entityId))
+                .where(i.entityType.eq(EntityType.EVENT)
+                        .and(pg.isEvent.eq(true))
+                        .and(pg.startDate.gt(today)))
+                .fetch();
     }
 }

--- a/src/main/java/com/api/stuv/domain/party/service/PartyService.java
+++ b/src/main/java/com/api/stuv/domain/party/service/PartyService.java
@@ -2,6 +2,7 @@ package com.api.stuv.domain.party.service;
 
 import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.service.S3ImageService;
+import com.api.stuv.domain.party.dto.response.MemberResponse;
 import com.api.stuv.domain.party.dto.request.PartyCreateRequest;
 import com.api.stuv.domain.party.dto.response.*;
 import com.api.stuv.domain.party.entity.GroupMember;
@@ -17,6 +18,7 @@ import com.api.stuv.global.exception.NotFoundException;
 import com.api.stuv.global.response.PageResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -87,6 +89,23 @@ public class PartyService {
                         dto.partyId()
                 ))
                 .toList();
+    }
+
+    public PageResponse<MemberResponse> getPartyMemberList(Long partyId, Long userId, Pageable pageable) {
+        return PageResponse.of(new PageImpl<>(
+                memberRepository.findMemberList(partyId, userId, pageable)
+                        .stream()
+                        .map(dto -> new MemberResponse(
+                                dto.friendId(),
+                                dto.userId(),
+                                dto.nickname(),
+                                s3ImageService.generateImageFile(EntityType.COSTUME, dto.imageId(), dto.image()),
+                                dto.context(),
+                                dto.status()
+                        )).toList(),
+                pageable,
+                memberRepository.countAllGroupMembers(partyId)
+        ));
     }
 
     @Transactional

--- a/src/main/java/com/api/stuv/domain/party/service/PartyService.java
+++ b/src/main/java/com/api/stuv/domain/party/service/PartyService.java
@@ -1,10 +1,9 @@
 package com.api.stuv.domain.party.service;
 
+import com.api.stuv.domain.image.entity.EntityType;
+import com.api.stuv.domain.image.service.S3ImageService;
 import com.api.stuv.domain.party.dto.request.PartyCreateRequest;
-import com.api.stuv.domain.party.dto.response.PartyDetailResponse;
-import com.api.stuv.domain.party.dto.response.PartyGroupResponse;
-import com.api.stuv.domain.party.dto.response.PartyIdResponse;
-import com.api.stuv.domain.party.dto.response.PartyRewardStatusResponse;
+import com.api.stuv.domain.party.dto.response.*;
 import com.api.stuv.domain.party.entity.GroupMember;
 import com.api.stuv.domain.party.entity.PartyGroup;
 import com.api.stuv.domain.party.entity.QuestStatus;
@@ -33,6 +32,7 @@ public class PartyService {
     private final PartyGroupRepository partyRepository;
     private final UserRepository userRepository;
     private final GroupMemberRepository memberRepository;
+    private final S3ImageService s3ImageService;
 
     public PageResponse<PartyGroupResponse> getPendingPartyGroups(String name, Pageable pageable) {
         return partyRepository.findPendingGroupsByName(name, pageable);
@@ -77,6 +77,16 @@ public class PartyService {
     public PartyDetailResponse getPartyDetailInfo(Long partyId, Long userId) {
         return partyRepository.findDetailByUserId(partyId, userId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PARTY_NOT_FOUND));
+    }
+
+    public List<EventBannerResponse> getEventList() {
+        return partyRepository.findEventPartyList()
+                .stream()
+                .map(dto -> new EventBannerResponse(
+                        s3ImageService.generateImageFile(EntityType.EVENT, dto.partyId(), dto.image()),
+                        dto.partyId()
+                ))
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/com/api/stuv/domain/party/service/PartyService.java
+++ b/src/main/java/com/api/stuv/domain/party/service/PartyService.java
@@ -92,6 +92,8 @@ public class PartyService {
     }
 
     public PageResponse<MemberResponse> getPartyMemberList(Long partyId, Long userId, Pageable pageable) {
+        if (!userRepository.existsById(userId)) throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
+        if (!partyRepository.existsById(partyId)) throw new NotFoundException(ErrorCode.PARTY_NOT_FOUND);
         return PageResponse.of(new PageImpl<>(
                 memberRepository.findMemberList(partyId, userId, pageable)
                         .stream()

--- a/src/main/java/com/api/stuv/domain/timer/controller/TimerController.java
+++ b/src/main/java/com/api/stuv/domain/timer/controller/TimerController.java
@@ -60,13 +60,14 @@ public class TimerController {
     }
 
     @Operation(summary = "회원 월간 공부 시간 조회 API", description = "회원이 월간 동안 공부한 시간을 조회합니다.")
-    @GetMapping("/time/monthly")
+    @GetMapping("/time/monthly/{userId}")
     public ResponseEntity<ApiResponse<List<StudyDateTimeResponse>>> monthlyStudyTime(
+            @PathVariable Long userId,
             @RequestParam int year,
             @RequestParam int month
     ) {
         return ResponseEntity.ok().body(ApiResponse.success(
-                timerService.getMonthlyStudyRecord(year, month)
+                timerService.getMonthlyStudyRecord(year, month, userId)
         ));
     }
 

--- a/src/main/java/com/api/stuv/domain/timer/service/TimerService.java
+++ b/src/main/java/com/api/stuv/domain/timer/service/TimerService.java
@@ -108,11 +108,9 @@ public class TimerService {
         timerRepository.delete(timer);
     }
 
-    public List<StudyDateTimeResponse> getMonthlyStudyRecord(int year, int month) {
+    public List<StudyDateTimeResponse> getMonthlyStudyRecord(int year, int month, Long userId) {
         LocalDate firstDay = LocalDate.of(year, month, 1);
         LocalDate lastDay = YearMonth.of(year, month).atEndOfMonth();
-
-        Long userId = tokenUtil.getUserId();
         if (!userRepository.existsById(userId)) throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
 
         Map<LocalDate, Long> studyMap = studyTimeRepository.sumTotalStudyTimeByDate(userId, firstDay, lastDay);

--- a/src/main/java/com/api/stuv/domain/user/entity/UserStatus.java
+++ b/src/main/java/com/api/stuv/domain/user/entity/UserStatus.java
@@ -1,0 +1,8 @@
+package com.api.stuv.domain.user.entity;
+
+public enum UserStatus {
+    NOT_FRIEND,
+    SENDER,
+    RECEIVER,
+    FRIEND,
+}

--- a/src/main/java/com/api/stuv/global/exception/ErrorCode.java
+++ b/src/main/java/com/api/stuv/global/exception/ErrorCode.java
@@ -41,7 +41,7 @@ public enum ErrorCode {
     HTTP_API_ERROR(400, -3010, "HTTP API에서 오류가 발생했습니다."),
     JSON_PARSING_ERROR(400, -3011, "JSON 파싱이 잘못되었습니다."),
     ARGUMENT_TYPE_MISMATCH(400, -3012, "올바르지 않은 파라미터입니다."),
-    DATE_FORMAT_MISMATCH(400, -3013, "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"),
+    INVALID_DATE_FORMAT(400, -3013, "날짜 형식이 올바르지 않습니다."),
     INVALID_ARGUMENT_METHOD(400, -3014, "데이터 유효성 검증에 실패했습니다."),
     REDIS_NOT_CONNECTED(500, -3015, "Redis 서버에 연결할 수 없습니다."),
     DATABASE_ERROR(500, -3100, "데이터베이스 처리 중 오류가 발생했습니다."),
@@ -75,7 +75,7 @@ public enum ErrorCode {
     // IMAGE
     IMAGE_NAME_NOT_FOUND(404, -8000, "해당 이미지를 찾을 수 없습니다."),
 
-    // TODO
+    // TODOLIST
     TODOLIST_NOT_FOUND(409, -9000, "TODOLIST가 없습니다."),
     TODO_NOT_FOUND(404, -900, "해당 TODO를 찾을 수 없습니다."),
     TODO_SAVE_FAILED(400, -9002, "TODO 저장에 실패했습니다."),

--- a/src/main/java/com/api/stuv/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/api/stuv/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.messaging.handler.annotation.support.MethodArgumentTy
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.time.DateTimeException;
 import java.time.format.DateTimeParseException;
 
 @Slf4j
@@ -42,11 +43,19 @@ public class GlobalExceptionHandler {
     // 날짜 변환 관련 예외
     @ExceptionHandler(DateTimeParseException.class)
     public ResponseEntity<ApiResponse<Void>> handleDateTimeParseException(DateTimeParseException e) {
-        ErrorCode errorCode = ErrorCode.DATE_FORMAT_MISMATCH;
+        ErrorCode errorCode = ErrorCode.INVALID_DATE_FORMAT;
         log.error("[ERROR] handleDateTimeParseException - {}", e.getMessage());
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.error(errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(DateTimeException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleDateTimeException(DateTimeException e) {
+        log.error("[ERROR] handleDateTimeException - {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_DATE_FORMAT.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_DATE_FORMAT.getMessage()));
     }
 
     @ExceptionHandler(ExpressionException.class)


### PR DESCRIPTION
## 📌 작업 설명
- 팟 참여자 목록 조회 및 이벤트 배너 조회 기능 구현

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #243 

## 🧑‍💻 요구 사항과 구현 내용
- 팟 참여자 목록 조회 기능
- 이벤트 배너 조회 기능
- 월간 공부시간 조회 API 접근 방식 변경

## ✅ 피드백 반영사항 

## ✅ PR 포인트 & 궁금한 점
