### PR TITLE
[#256] 관리자 주간 정보 조회 및 최근 매출 내역 조회

### DIFF
--- a/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
@@ -3,6 +3,7 @@ package com.api.stuv.domain.admin.controller;
 import com.api.stuv.domain.admin.dto.request.ConfirmRequest;
 import com.api.stuv.domain.admin.dto.request.CostumeRequest;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
+import com.api.stuv.domain.admin.dto.response.WeeklyInfoResponse;
 import com.api.stuv.domain.image.dto.ImageResponse;
 import com.api.stuv.domain.admin.service.AdminService;
 import com.api.stuv.domain.admin.dto.response.AdminPartyGroupResponse;
@@ -29,6 +30,15 @@ import java.time.LocalDate;
 public class AdminController {
 
     private final AdminService adminService;
+
+    @GetMapping
+    @Operation(summary = "주간 서비스 이용 정보 조회 API", description = "주간 서비스 이용 정보를 볼 수 있습니다.")
+    public ResponseEntity<ApiResponse<WeeklyInfoResponse>> getAdminPartyGroups() {
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(
+                        adminService.weeklyInfo()
+                ));
+    }
 
     @PostMapping(value = "/costume", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "코스튬 등록 API", description = "신규 코스튬을 등록합니다.")

--- a/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/api/stuv/domain/admin/controller/AdminController.java
@@ -3,6 +3,7 @@ package com.api.stuv.domain.admin.controller;
 import com.api.stuv.domain.admin.dto.request.ConfirmRequest;
 import com.api.stuv.domain.admin.dto.request.CostumeRequest;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
+import com.api.stuv.domain.admin.dto.response.PointSalesResponse;
 import com.api.stuv.domain.admin.dto.response.WeeklyInfoResponse;
 import com.api.stuv.domain.image.dto.ImageResponse;
 import com.api.stuv.domain.admin.service.AdminService;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,6 +39,15 @@ public class AdminController {
         return ResponseEntity.ok()
                 .body(ApiResponse.success(
                         adminService.weeklyInfo()
+                ));
+    }
+
+    @GetMapping("/payment")
+    @Operation(summary = "최근 매출 내역 조회 API", description = "최근 5개 까지의 매출 내역을 조회할 수 있습니다.")
+    public ResponseEntity<ApiResponse<List<PointSalesResponse>>> getAdminPointSales() {
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(
+                        adminService.getPointSalesList()
                 ));
     }
 

--- a/src/main/java/com/api/stuv/domain/admin/dto/response/PointSalesResponse.java
+++ b/src/main/java/com/api/stuv/domain/admin/dto/response/PointSalesResponse.java
@@ -1,0 +1,11 @@
+package com.api.stuv.domain.admin.dto.response;
+
+import java.math.BigDecimal;
+
+public record PointSalesResponse(
+        String createdAt,
+        String nickname,
+        BigDecimal amount,
+        BigDecimal point
+) {
+}

--- a/src/main/java/com/api/stuv/domain/admin/dto/response/WeeklyInfoResponse.java
+++ b/src/main/java/com/api/stuv/domain/admin/dto/response/WeeklyInfoResponse.java
@@ -1,0 +1,10 @@
+package com.api.stuv.domain.admin.dto.response;
+
+import java.math.BigDecimal;
+
+public record WeeklyInfoResponse(
+        Long weeklySignupUser,
+        String image,
+        BigDecimal weeklyPointSales
+) {
+}

--- a/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
+++ b/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
@@ -4,8 +4,10 @@ import com.api.stuv.domain.admin.dto.MemberDetailDTO;
 import com.api.stuv.domain.admin.dto.request.ConfirmRequest;
 import com.api.stuv.domain.admin.dto.request.CostumeRequest;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
+import com.api.stuv.domain.admin.dto.response.WeeklyInfoResponse;
 import com.api.stuv.domain.admin.exception.CostumeNotFound;
 import com.api.stuv.domain.admin.exception.InvalidPointFormat;
+import com.api.stuv.domain.image.dto.ImageDTO;
 import com.api.stuv.domain.image.dto.ImageResponse;
 import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.entity.ImageFile;
@@ -23,6 +25,8 @@ import com.api.stuv.domain.party.repository.member.GroupMemberRepository;
 import com.api.stuv.domain.party.repository.party.PartyGroupRepository;
 import com.api.stuv.domain.shop.entity.Costume;
 import com.api.stuv.domain.shop.repository.CostumeRepository;
+import com.api.stuv.domain.user.repository.PointHistoryRepository;
+import com.api.stuv.domain.user.repository.UserRepository;
 import com.api.stuv.global.exception.DateOutOfRangeException;
 import com.api.stuv.global.exception.ErrorCode;
 import com.api.stuv.global.exception.NotFoundException;
@@ -35,7 +39,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 @Service
@@ -49,6 +56,8 @@ public class AdminService {
     private final PartyGroupRepository partyGroupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final QuestConfirmRepository questConfirmRepository;
+    private final UserRepository userRepository;
+    private final PointHistoryRepository historyRepository;
 
     @Transactional
     public void createCostume(CostumeRequest request, MultipartFile file) {
@@ -118,5 +127,22 @@ public class AdminService {
         if (groupMemberRepository.isMemberNotProgressByGroupId(partyId)) {
             partyGroupRepository.updatePartyStatusForPartyGroup(partyId, PartyStatus.APPROVED);
         }
+    }
+
+    public WeeklyInfoResponse weeklyInfo() {
+        LocalDateTime startOfWeek = LocalDate.now()
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                .atStartOfDay();
+
+        LocalDateTime endOfWeek = LocalDate.now()
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                .with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+                .atTime(23, 59, 59);
+
+        Long users = userRepository.countNewUserByWeekend(startOfWeek, endOfWeek);
+        ImageDTO imageDTO = costumeRepository.findCostumeByBestSales();
+        BigDecimal point = historyRepository.sumWeekendSalesPoint(startOfWeek, endOfWeek);
+
+        return new WeeklyInfoResponse(users, s3ImageService.generateImageFile(EntityType.COSTUME, imageDTO.entityId(), imageDTO.image()), point);
     }
 }

--- a/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
+++ b/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
@@ -4,6 +4,7 @@ import com.api.stuv.domain.admin.dto.MemberDetailDTO;
 import com.api.stuv.domain.admin.dto.request.ConfirmRequest;
 import com.api.stuv.domain.admin.dto.request.CostumeRequest;
 import com.api.stuv.domain.admin.dto.response.AdminPartyAuthDetailResponse;
+import com.api.stuv.domain.admin.dto.response.PointSalesResponse;
 import com.api.stuv.domain.admin.dto.response.WeeklyInfoResponse;
 import com.api.stuv.domain.admin.exception.CostumeNotFound;
 import com.api.stuv.domain.admin.exception.InvalidPointFormat;
@@ -25,6 +26,7 @@ import com.api.stuv.domain.party.repository.member.GroupMemberRepository;
 import com.api.stuv.domain.party.repository.party.PartyGroupRepository;
 import com.api.stuv.domain.shop.entity.Costume;
 import com.api.stuv.domain.shop.repository.CostumeRepository;
+import com.api.stuv.domain.shop.repository.PaymentRepository;
 import com.api.stuv.domain.user.repository.PointHistoryRepository;
 import com.api.stuv.domain.user.repository.UserRepository;
 import com.api.stuv.global.exception.DateOutOfRangeException;
@@ -58,6 +60,7 @@ public class AdminService {
     private final QuestConfirmRepository questConfirmRepository;
     private final UserRepository userRepository;
     private final PointHistoryRepository historyRepository;
+    private final PaymentRepository paymentRepository;
 
     @Transactional
     public void createCostume(CostumeRequest request, MultipartFile file) {
@@ -144,5 +147,9 @@ public class AdminService {
         BigDecimal point = historyRepository.sumWeekendSalesPoint(startOfWeek, endOfWeek);
 
         return new WeeklyInfoResponse(users, s3ImageService.generateImageFile(EntityType.COSTUME, imageDTO.entityId(), imageDTO.image()), point);
+    }
+
+    public List<PointSalesResponse> getPointSalesList() {
+        return paymentRepository.findPointSalesList();
     }
 }

--- a/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
+++ b/src/main/java/com/api/stuv/domain/admin/service/AdminService.java
@@ -108,7 +108,7 @@ public class AdminService {
         Tuple tp = questConfirmRepository.findGroupMemberConfirmImageByDate(partyId, memberId, date);
         if (tp == null) throw new NotFoundException(ErrorCode.CONFIRM_NOT_FOUND);
 
-        return new ImageResponse(s3ImageService.generateImageFile(EntityType.CONFIRM, tp.get(1, Long.class), tp.get(2, String.class)));
+        return new ImageResponse(s3ImageService.generateImageFile(EntityType.CONFIRM, tp.get(0, Long.class), tp.get(1, String.class)));
     }
 
     @Transactional

--- a/src/main/java/com/api/stuv/domain/image/dto/ImageDTO.java
+++ b/src/main/java/com/api/stuv/domain/image/dto/ImageDTO.java
@@ -1,0 +1,7 @@
+package com.api.stuv.domain.image.dto;
+
+public record ImageDTO(
+        Long entityId,
+        String image
+) {
+}

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
@@ -72,7 +72,7 @@ public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
                 .join(gm).on(pg.id.eq(gm.groupId))
                 .where(pg.startDate.loe(LocalDate.now())
                         .and(pg.endDate.goe(LocalDate.now()))
-                        .and(pg.id.eq(userId)))
+                        .and(gm.userId.eq(userId)))
                 .orderBy(pg.endDate.desc())
                 .groupBy(pg.id, pg.name, pg.recruitCap, pg.endDate)
                 .fetch();

--- a/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.api.stuv.domain.shop.repository;
 
+import com.api.stuv.domain.image.dto.ImageDTO;
 import com.api.stuv.domain.shop.dto.costume.CostumeDTO;
 import com.api.stuv.global.response.PageResponse;
 import org.springframework.data.domain.Pageable;
@@ -7,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.Optional;
 
 public interface CostumeRepositoryCustom {
+    ImageDTO findCostumeByBestSales();
     PageResponse<CostumeDTO> getCostumeList(Pageable pageable);
     Optional<CostumeDTO> getCostume(Long id);
 }

--- a/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/CostumeRepositoryImpl.java
@@ -1,6 +1,11 @@
 package com.api.stuv.domain.shop.repository;
 
+import com.api.stuv.domain.image.dto.ImageDTO;
 import com.api.stuv.domain.image.entity.EntityType;
+import com.api.stuv.domain.image.entity.QImageFile;
+import com.api.stuv.domain.image.service.S3ImageService;
+import com.api.stuv.domain.shop.entity.QCostume;
+import com.api.stuv.domain.user.entity.QUserCostume;
 import com.api.stuv.domain.shop.dto.costume.CostumeDTO;
 import com.api.stuv.global.response.PageResponse;
 import com.querydsl.core.Tuple;
@@ -20,6 +25,9 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class CostumeRepositoryImpl implements CostumeRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
+    private final QCostume qCostume = QCostume.costume;
+    private final QImageFile qImageFile = QImageFile.imageFile;
+    private final QUserCostume uc = QUserCostume.userCostume;
 
     @Override
     public PageResponse<CostumeDTO> getCostumeList(Pageable pageable) {
@@ -61,5 +69,23 @@ public class CostumeRepositoryImpl implements CostumeRepositoryCustom {
                 result.get(costume.costumeName),
                 result.get(costume.point)
         ));
+    }
+
+    @Override
+    public ImageDTO findCostumeByBestSales() {
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        ImageDTO.class,
+                        qCostume.id,
+                        qImageFile.newFilename
+                ))
+                .from(qCostume)
+                .leftJoin(uc).on(qCostume.id.eq(uc.costumeId))
+                .leftJoin(qImageFile).on(qCostume.id.eq(qImageFile.entityId)
+                        .and(qImageFile.entityType.eq(EntityType.COSTUME)))
+                .where(qCostume.id.ne(1L))
+                .groupBy(qCostume.id, qImageFile.newFilename)
+                .orderBy(uc.count().desc())
+                .fetchFirst();
     }
 }

--- a/src/main/java/com/api/stuv/domain/shop/repository/PaymentRepository.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/PaymentRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PaymentRepository extends JpaRepository<Payment, Long> {
+public interface PaymentRepository extends JpaRepository<Payment, Long>, PaymentRepositoryCustom {
     Payment findByOrderId(@NotBlank(message = "고유 주문 번호를 입력해주세요") String s);
 }

--- a/src/main/java/com/api/stuv/domain/shop/repository/PaymentRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/PaymentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.api.stuv.domain.shop.repository;
+
+import com.api.stuv.domain.admin.dto.response.PointSalesResponse;
+
+import java.util.List;
+
+public interface PaymentRepositoryCustom {
+    List<PointSalesResponse> findPointSalesList();
+}

--- a/src/main/java/com/api/stuv/domain/shop/repository/PaymentRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/PaymentRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.api.stuv.domain.shop.repository;
+
+import com.api.stuv.domain.admin.dto.response.PointSalesResponse;
+import com.api.stuv.domain.shop.entity.QPayment;
+import com.api.stuv.domain.user.entity.QUser;
+import com.api.stuv.global.util.common.TemplateUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
+
+    private final JPAQueryFactory factory;
+    private final QPayment p = QPayment.payment;
+    private final QUser u = QUser.user;
+
+    @Override
+    public List<PointSalesResponse> findPointSalesList() {
+        return factory
+                .select(Projections.constructor(
+                        PointSalesResponse.class,
+                        TemplateUtils.timeFormater(p.createdAt),
+                        u.nickname,
+                        p.amount,
+                        p.point
+                ))
+                .from(p)
+                .leftJoin(u).on(p.userId.eq(u.id))
+                .fetch();
+    }
+}

--- a/src/main/java/com/api/stuv/domain/user/repository/PointHistoryRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/PointHistoryRepositoryCustom.java
@@ -1,5 +1,9 @@
 package com.api.stuv.domain.user.repository;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
 public interface PointHistoryRepositoryCustom {
     boolean existsHistoryByUserIdBetweenWeekends(Long userId);
+    BigDecimal sumWeekendSalesPoint(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/api/stuv/domain/user/repository/PointHistoryRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/PointHistoryRepositoryImpl.java
@@ -5,10 +5,12 @@ import com.api.stuv.domain.user.entity.QPointHistory;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class PointHistoryRepositoryImpl implements PointHistoryRepositoryCustom {
@@ -29,5 +31,17 @@ public class PointHistoryRepositoryImpl implements PointHistoryRepositoryCustom 
                         .and(ph.createdAt.between(startOfWeek, endOfWeek))
                         .and(ph.transactionType.eq(HistoryType.RANKING)))
                 .fetchFirst() != null;
+    }
+
+    @Override
+    public BigDecimal sumWeekendSalesPoint(LocalDateTime startDate, LocalDateTime endDate) {
+        return Optional.ofNullable(
+                factory
+                        .select(ph.amount.sum())
+                        .from(ph)
+                        .where(ph.createdAt.between(startDate, endDate)
+                                .and(ph.transactionType.eq(HistoryType.CHARGE)))
+                        .fetchOne()
+        ).orElse(BigDecimal.ZERO);
     }
 }

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
@@ -7,6 +7,8 @@ import com.api.stuv.domain.user.dto.response.UserInformationResponse;
 import com.api.stuv.domain.user.dto.response.MyInformationResponse;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface UserRepositoryCustom {
@@ -16,4 +18,5 @@ public interface UserRepositoryCustom {
     List<GetCostume> getUserCostume(@Param("userId") Long userId);
     String getCostumeInfoByUserId(Long userId);
     List<UserProfileInfoDTO> findUserInfoByIds(List<Long> userIds);
+    Long countNewUserByWeekend(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryImpl.java
@@ -21,7 +21,9 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepositoryCustom{
@@ -196,4 +198,14 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
         );
     }
 
+    @Override
+    public Long countNewUserByWeekend(LocalDateTime startDate, LocalDateTime endDate) {
+        return Optional.ofNullable(jpaQueryFactory
+                .select(
+                        u.id.count()
+                ).from(u)
+                .where(u.createdAt.between(startDate, endDate))
+                .fetchOne())
+                .orElse(0L);
+    }
 }


### PR DESCRIPTION
## 📌 작업 설명
- 관리자 주간 정보 조회 및 최근 매출 내역 조회

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #256 

## 🧑‍💻 요구 사항과 구현 내용
- 관리자 주간 정보 조회
- 최근 매출 내역 조회
- 팟 인증 사진 조회 기능 버그 픽스

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
