### PR TITLE
[#271] 관리자 팟 상세 인증 멤버의 상태가 null값으로 표시되던 문제 해결

### DIFF
--- a/src/main/java/com/api/stuv/domain/admin/dto/MemberDetailDTO.java
+++ b/src/main/java/com/api/stuv/domain/admin/dto/MemberDetailDTO.java
@@ -1,8 +1,12 @@
 package com.api.stuv.domain.admin.dto;
 
+import com.api.stuv.domain.party.entity.ConfirmStatus;
+
 public record MemberDetailDTO(
         Long memberId,
-        String profile,
         String nickname,
-        String isAuth
-) {}
+        ConfirmStatus status,
+        String filename,
+        Long costumeId
+) {
+}

--- a/src/main/java/com/api/stuv/domain/admin/dto/response/AdminPartyAuthDetailResponse.java
+++ b/src/main/java/com/api/stuv/domain/admin/dto/response/AdminPartyAuthDetailResponse.java
@@ -1,7 +1,5 @@
 package com.api.stuv.domain.admin.dto.response;
 
-import com.api.stuv.domain.admin.dto.MemberDetailDTO;
-
 import java.time.LocalDate;
 import java.util.List;
 
@@ -10,9 +8,9 @@ public record AdminPartyAuthDetailResponse(
         String context,
         LocalDate startDate,
         LocalDate endDate,
-        List<MemberDetailDTO> members
+        List<MemberDetailResponse> members
 ) {
-    public static AdminPartyAuthDetailResponse from(AdminPartyAuthDetailResponse response, List<MemberDetailDTO> members) {
+    public static AdminPartyAuthDetailResponse from(AdminPartyAuthDetailResponse response, List<MemberDetailResponse> members) {
         return new AdminPartyAuthDetailResponse(
                 response.name,
                 response.context,

--- a/src/main/java/com/api/stuv/domain/admin/dto/response/MemberDetailResponse.java
+++ b/src/main/java/com/api/stuv/domain/admin/dto/response/MemberDetailResponse.java
@@ -1,0 +1,8 @@
+package com.api.stuv.domain.admin.dto.response;
+
+public record MemberDetailResponse(
+        Long memberId,
+        String profile,
+        String nickname,
+        String isAuth
+) {}

--- a/src/main/java/com/api/stuv/domain/party/entity/QuestConfirm.java
+++ b/src/main/java/com/api/stuv/domain/party/entity/QuestConfirm.java
@@ -1,6 +1,5 @@
 package com.api.stuv.domain.party.entity;
 
-
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;


### PR DESCRIPTION
## 📌 작업 설명
- 관리자 팟 상세 인증 멤버의 상태가 null값으로 표시되던 문제 해결

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #271 

## 🧑‍💻 요구 사항과 구현 내용
- 관리자 팟 상세 인증 멤버의 상태가 null값으로 표시되던 문제 해결

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
