### PR TITLE
[#291] 채팅방 멤버 정보 전송 및 응답 수정

### DIFF
--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryCustom.java
@@ -26,4 +26,5 @@ public interface PartyGroupRepositoryCustom {
     Optional<MemberRewardStatusDTO> findCompleteParty(Long partyId, Long userId);
     List<EventPartyResponse> findEventPartyList(Pageable pageable);
     Long countEventParty();
+    Long findGroupIdByRoomName(String roomName);
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/party/PartyGroupRepositoryImpl.java
@@ -240,4 +240,12 @@ public class PartyGroupRepositoryImpl implements PartyGroupRepositoryCustom {
                         .fetchOne()
         ).orElse(0L);
     }
+
+    @Override
+    public Long findGroupIdByRoomName(String roomName) {
+        return factory.select(pg.id)
+                .from(pg)
+                .where(pg.name.eq(roomName))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -26,7 +26,15 @@ public class ChatController {
     private final ChatRoomMemberService chatRoomMemberService;
     private final TokenUtil tokenUtil;
 
-    @Operation(summary = "채팅방 목록 리스트 API", description = "user가 포함된 채팅방 목록을 가져옵니다.")
+    @Operation(summary = "타이틀별 채팅방 목록 조회 API", description = "user가 포함된 채팅방을 타이틀별로 구분하여 정보를 가져옵니다.")
+    @GetMapping("/listInfoByTitle")
+    public ResponseEntity<ApiResponse<List<ChatRoomInfoResponse>>> getRoomInfoListBySenderId(
+    ) {
+        List<ChatRoomInfoResponse> roomList = chatRoomDetailService.getChatRoomInfoByUserId(tokenUtil.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(roomList));
+    }
+
+    @Operation(summary = "채팅방 목록 조회 API", description = "user가 포함된 채팅방 목록을 가져옵니다.")
     @GetMapping("/list")
     public ResponseEntity<ApiResponse<List<ChatRoomResponse>>> getRoomListBySenderId() {
         List<ChatRoomResponse> roomList = chatRoomDetailService.getSortedRoomListBySenderId(tokenUtil.getUserId());

--- a/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomInfoResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomInfoResponse.java
@@ -1,0 +1,27 @@
+package com.api.stuv.domain.socket.dto;
+import com.api.stuv.domain.socket.entity.ChatRoom;
+
+public record ChatRoomInfoResponse(
+        String roomId,
+        String roomType,
+        UserInfo userInfo,
+        GroupInfo groupInfo
+) {
+    public static ChatRoomInfoResponse privateChat(ChatRoom room, UserInfo userInfo) {
+        return new ChatRoomInfoResponse(
+                room.getRoomId(),
+                room.getRoomType(),
+                userInfo,
+                null
+        );
+    }
+
+    public static ChatRoomInfoResponse groupChat(ChatRoom room, GroupInfo groupInfo) {
+        return new ChatRoomInfoResponse(
+                room.getRoomId(),
+                room.getRoomType(),
+                null,
+                groupInfo
+        );
+    }
+}

--- a/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomResponse.java
@@ -21,7 +21,7 @@ public record ChatRoomResponse(
                 room.getRoomType(),
                 lastUserInfo,
                 latestMessage != null ? latestMessage.getMessage() : "대화 내역 없음",
-                latestMessage != null ? latestMessage.getCreatedAt() : LocalDateTime.MIN,
+                latestMessage != null ? latestMessage.getCreatedAt() : LocalDateTime.MAX,
                 unreadCount
         );
     }

--- a/src/main/java/com/api/stuv/domain/socket/dto/GroupInfo.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/GroupInfo.java
@@ -1,0 +1,8 @@
+package com.api.stuv.domain.socket.dto;
+
+public record GroupInfo(
+        Long groupId,
+        String groupName,
+        int totalMembers
+) {
+}

--- a/src/main/java/com/api/stuv/domain/socket/service/ChatRoomDetailService.java
+++ b/src/main/java/com/api/stuv/domain/socket/service/ChatRoomDetailService.java
@@ -86,7 +86,7 @@ public class ChatRoomDetailService {
 
     public String createGroupChatRoom(String groupName, Long userId, int maxMembers) {
         String roomId = groupName;
-        boolean exists = chatRoomRepository.existsByRoomId(roomId);
+        boolean exists = chatRoomRepository.existsByRoomId(groupName);
 
         if (exists) {
             throw new NotFoundException(ErrorCode.CHAT_ROOM_ALREADY_EXISTS);
@@ -96,7 +96,7 @@ public class ChatRoomDetailService {
         members.add(userId);
 
         ChatRoom chatRoom = ChatRoom.builder()
-                .roomId(roomId)
+                .roomId(UUID.randomUUID().toString().replace("-", ""))
                 .roomType("GROUP")
                 .roomName(groupName)
                 .members(members)
@@ -106,7 +106,7 @@ public class ChatRoomDetailService {
 
         chatRoomRepository.save(chatRoom);
 
-        return roomId;
+        return chatRoom.getRoomId();
     }
 
     public void addUserToGroupChat(String roomId, Long newUserId) {

--- a/src/main/java/com/api/stuv/domain/socket/service/ChatRoomDetailService.java
+++ b/src/main/java/com/api/stuv/domain/socket/service/ChatRoomDetailService.java
@@ -2,7 +2,11 @@ package com.api.stuv.domain.socket.service;
 
 import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.service.S3ImageService;
+import com.api.stuv.domain.party.repository.member.GroupMemberRepository;
+import com.api.stuv.domain.party.repository.party.PartyGroupRepository;
+import com.api.stuv.domain.socket.dto.ChatRoomInfoResponse;
 import com.api.stuv.domain.socket.dto.ChatRoomResponse;
+import com.api.stuv.domain.socket.dto.GroupInfo;
 import com.api.stuv.domain.socket.dto.UserInfo;
 import com.api.stuv.domain.socket.entity.ChatMessage;
 import com.api.stuv.domain.socket.entity.ChatRoom;
@@ -24,6 +28,7 @@ import java.util.stream.Collectors;
 public class ChatRoomDetailService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final PartyGroupRepository partyGroupRepository;
     private final UserRepository userRepository;
     private final S3ImageService s3ImageService;
 
@@ -129,5 +134,55 @@ public class ChatRoomDetailService {
         }
         chatRoomRepository.deleteByRoomId(roomId);
         chatMessageRepository.deleteByRoomId(roomId);
+    }
+
+    public List<ChatRoomInfoResponse> getChatRoomInfoByUserId(Long senderId) {
+        List<ChatRoom> chatRooms = chatRoomRepository.findByMembersContaining(senderId);
+
+        if (chatRooms.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return chatRooms.stream()
+                .map(room -> {
+                    if ("PRIVATE".equals(room.getRoomType())) {
+                        return handlePrivateChat(room, senderId);
+                    } else if ("GROUP".equals(room.getRoomType())) {
+                        return handleGroupChat(room);
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private ChatRoomInfoResponse handlePrivateChat(ChatRoom room, Long senderId) {
+        List<Long> members = room.getMembers();
+        Long otherUserId = members.stream()
+                .filter(id -> !id.equals(senderId))
+                .findFirst()
+                .orElse(null);
+
+        if (otherUserId == null) {
+            return null;
+        }
+
+        String nickName = userRepository.findNicknameByUserId(otherUserId);
+        ImageUrlDTO response = userRepository.getCostumeInfoByUserId(otherUserId);
+        String profileImage = (response != null) ?
+                s3ImageService.generateImageFile(EntityType.COSTUME, response.entityId(), response.newFileName())
+                : null;
+
+        UserInfo otherUserInfo = new UserInfo(otherUserId, nickName, profileImage);
+        return ChatRoomInfoResponse.privateChat(room, otherUserInfo);
+    }
+
+    private ChatRoomInfoResponse handleGroupChat(ChatRoom room) {
+        Long groupId = partyGroupRepository.findGroupIdByRoomName(room.getRoomName());
+        int totalMembers = room.getMembers().size();
+        String groupName = room.getRoomName();
+
+        GroupInfo groupInfo = new GroupInfo(groupId, groupName, totalMembers);
+        return ChatRoomInfoResponse.groupChat(room, groupInfo);
     }
 }

--- a/src/main/java/com/api/stuv/domain/socket/service/ChatRoomMemberService.java
+++ b/src/main/java/com/api/stuv/domain/socket/service/ChatRoomMemberService.java
@@ -44,7 +44,8 @@ public class ChatRoomMemberService {
     // 특정 채팅방의 사용자 목록을 업데이트 (새로운 멤버 추가 시)
     public void updateRoomMembers(String roomId) {
         ChatRoom chatRoom = chatRoomRepository.findByRoomId(roomId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));        List<Long> members = chatRoom.getMembers();
+                .orElseThrow(() -> new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        List<Long> members = chatRoom.getMembers();
         roomSessions.put(roomId, new ArrayList<>(members));
     }
     // 읽음 처리 계산
@@ -81,7 +82,7 @@ public class ChatRoomMemberService {
 
         System.out.println("유저 세션: " + userSessions);
     }
-    // 사용자가 특정 방에서 나가면 userSessions에서 제거 (단, 다른 방에 남아 있다면 유지)
+    // 사용자가 특정 방에서 나가면 userSessions에서 제거
     public void userLeaveRoom(Long userId, String roomId) {
         Set<Long> members = userRoomSessions.get(roomId);
         if (members != null) {
@@ -106,7 +107,7 @@ public class ChatRoomMemberService {
         return userSessions.getOrDefault(userId, null);
     }
 
-    // 특정 채팅방의 사용자 목록 반환 (닉네임, 프로필 포함)
+    // 특정 채팅방의 사용자 목록 반환
     public List<UserInfo> getRoomMemberInfos(String roomId) {
         Set<Long> userIds = userRoomSessions.getOrDefault(roomId, Collections.emptySet());
 


### PR DESCRIPTION
## 📌 작업 설명
- 채팅방 멤버 정보 전송 및 응답 수정

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #291 

## 🧑‍💻 요구 사항과 구현 내용
- 타이틀별 채팅방 정보 조회 서비스 추가 및 GroupInfo 레코드 추가
- 그룹 채팅룸 id 등록 변경

## ✅ 피드백 반영사항


## ✅ PR 포인트 & 궁금한 점
