### PR TITLE
[#303] 팟 및 관리자 기능 핫픽스, 일부 출력문 제거

### DIFF
--- a/src/main/java/com/api/stuv/domain/alert/service/AlertService.java
+++ b/src/main/java/com/api/stuv/domain/alert/service/AlertService.java
@@ -24,7 +24,6 @@ public class AlertService {
     public void createAlert(Long targetUserId, Long typeId, AlertType alertType, String title, String nickname) {
         String alertId = UUID.randomUUID().toString();
         Alert alert = new Alert(alertId, typeId, alertType, title, nickname, false, LocalDateTime.now());
-        System.out.println("alertResponse = " + alert);
         redisService.saveByAlertId(getKey(targetUserId), alertId, alert);
         redisPublisher.publish(targetUserId, alert);
     }

--- a/src/main/java/com/api/stuv/domain/party/dto/response/PartyDetailResponse.java
+++ b/src/main/java/com/api/stuv/domain/party/dto/response/PartyDetailResponse.java
@@ -12,6 +12,7 @@ public record PartyDetailResponse(
         LocalDate startDate,
         LocalDate endDate,
         BigDecimal bettingPointCap,
-        boolean isJoined
+        boolean isJoined,
+        boolean isAuth
 ) {
 }

--- a/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepository.java
+++ b/src/main/java/com/api/stuv/domain/party/repository/confirm/QuestConfirmRepository.java
@@ -8,5 +8,5 @@ import java.time.LocalDate;
 
 @Repository
 public interface QuestConfirmRepository extends JpaRepository<QuestConfirm, Long>, QuestConfirmRepositoryCustom {
-    boolean existsByIdAndConfirmDate(Long id, LocalDate confirmDate);
+    boolean existsByMemberIdAndConfirmDate(Long memberId, LocalDate confirmDate);
 }

--- a/src/main/java/com/api/stuv/domain/party/service/PartyService.java
+++ b/src/main/java/com/api/stuv/domain/party/service/PartyService.java
@@ -193,7 +193,7 @@ public class PartyService {
         LocalDate today = LocalDate.now();
 
         if (isValidatePeriod(party, today)) throw new BusinessException(ErrorCode.PARTY_INVALID_DATE);
-        if (confirmRepository.existsByIdAndConfirmDate(memberId, today)) throw new BusinessException(ErrorCode.ALREADY_AUTH_TODAY);
+        if (confirmRepository.existsByMemberIdAndConfirmDate(memberId, today)) throw new BusinessException(ErrorCode.ALREADY_AUTH_TODAY);
 
         QuestConfirm confirm = new QuestConfirm(memberId, today);
 

--- a/src/main/java/com/api/stuv/domain/shop/repository/PaymentRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/shop/repository/PaymentRepositoryImpl.java
@@ -29,6 +29,9 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
                 ))
                 .from(p)
                 .leftJoin(u).on(p.userId.eq(u.id))
+                .where(p.isPaymentSuccess.eq(true))
+                .orderBy(p.createdAt.desc())
+                .limit(10)
                 .fetch();
     }
 }

--- a/src/main/java/com/api/stuv/domain/timer/service/TimerService.java
+++ b/src/main/java/com/api/stuv/domain/timer/service/TimerService.java
@@ -152,7 +152,6 @@ public class TimerService {
         for (String key : keys) {
             String studyTime = hashOps.get(key, today.toString());
             if (studyTime != null) {
-                System.out.println(Long.parseLong(studyTime));
                 totalStudyTime += Long.parseLong(studyTime);
             }
         }

--- a/src/main/java/com/api/stuv/domain/user/service/UserService.java
+++ b/src/main/java/com/api/stuv/domain/user/service/UserService.java
@@ -290,7 +290,6 @@ public class UserService {
 
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
         Long id = userCostumeRepository.findIdByCostumeId(costumeId, userId);
-        System.out.println(id);
         user.changeUserCostume(id);
         userRepository.save(user);
 


### PR DESCRIPTION
## 📌 작업 설명
- 만들어진 기능에 대한 간단한 설명

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #303 

## 🧑‍💻 요구 사항과 구현 내용
- 팟 상세에 isAuth 항목 추가
- 팟 상세 중복 인증에 대한 예외처리 확인
- 시작전인 팟 목록 시작일이 빠른 순서대로 정렬
- 참여중인 팟 목록 마감일이 빠른 순서대로 정렬
- 관리자 포인트 결제 이력 최신순 정렬 및 10개 데이터 제한
- 관리자 팟 관리 목록 시작일 기준으로 오래된 순 정렬

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
