### PR TITLE
[#306] 채팅방 1:1방, 그룹방 정보 응답 생성

### DIFF
--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -32,6 +32,14 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.success(roomList));
     }
 
+    @Operation(summary = "타입별 채팅방 목록 조회 API", description = "user가 포함된 채팅방을 타입별로 구분하여 정보를 가져옵니다.")
+    @GetMapping("/listInfoByType")
+    public ResponseEntity<ApiResponse<List<ChatRoomInfoResponse>>> getRoomInfoListBySenderId(
+    ) {
+        List<ChatRoomInfoResponse> roomList = chatRoomDetailService.getChatRoomInfoByUserId(tokenUtil.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(roomList));
+    }
+
     @Operation(summary = "메세지 요청 API", description = "채팅방 메세지를 요청을 합니다.")
     @GetMapping("/{roomId}/messages")
     public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessagesByRoomIdPage(

--- a/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomInfoResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomInfoResponse.java
@@ -1,0 +1,28 @@
+package com.api.stuv.domain.socket.dto;
+
+import com.api.stuv.domain.socket.entity.ChatRoom;
+
+public record ChatRoomInfoResponse(
+        String roomId,
+        String roomType,
+        UserInfo userInfo,
+        GroupInfo groupInfo
+) {
+    public static ChatRoomInfoResponse privateChat(ChatRoom room, UserInfo userInfo) {
+        return new ChatRoomInfoResponse(
+                room.getRoomId(),
+                room.getRoomType(),
+                userInfo,
+                null
+        );
+    }
+
+    public static ChatRoomInfoResponse groupChat(ChatRoom room, GroupInfo groupInfo) {
+        return new ChatRoomInfoResponse(
+                room.getRoomId(),
+                room.getRoomType(),
+                null,
+                groupInfo
+        );
+    }
+}


### PR DESCRIPTION
## 📌 작업 설명
- PRIVATE 및 GROUP 채팅방 정보 조회 추가

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #306 

## 🧑‍💻 요구 사항과 구현 내용
- PRIVATE 채팅방의 경우 senderId를 제외한 상대방 정보를 조회 추가
- GROUP 채팅방의 정보를 조회 추가

- 채팅방 생성 실패시 roomId 반환

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
