### PR TITLE
[#308]: 채팅방 1:1방, 그룹방 정보 응답 오류 수정

### DIFF
--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -32,14 +32,6 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.success(roomList));
     }
 
-    @Operation(summary = "타입별 채팅방 목록 조회 API", description = "user가 포함된 채팅방을 타입별로 구분하여 정보를 가져옵니다.")
-    @GetMapping("/listInfoByType")
-    public ResponseEntity<ApiResponse<List<ChatRoomInfoResponse>>> getRoomInfoListBySenderId(
-    ) {
-        List<ChatRoomInfoResponse> roomList = chatRoomDetailService.getChatRoomInfoByUserId(tokenUtil.getUserId());
-        return ResponseEntity.ok(ApiResponse.success(roomList));
-    }
-
     @Operation(summary = "메세지 요청 API", description = "채팅방 메세지를 요청을 합니다.")
     @GetMapping("/{roomId}/messages")
     public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessagesByRoomIdPage(

--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatMessageController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatMessageController.java
@@ -42,7 +42,7 @@ public class ChatMessageController {
         Long userId = readMessageRequest.userId();
 
         chatRoomMemberService.userJoinRoom(userId, roomId);
-        List<UserInfo> userInfo = chatRoomMemberService.getRoomMemberInfos(roomId);
+        ChatRoomTypeInfoResponse chatRoomTypeInfoResponse  = chatRoomDetailService.getChatRoomInfoByRoomName(userId, roomId);
 
         roomSessions.forEach((rooms, users) -> {
             if (!rooms.equals(roomId) && users.contains(userId)) {
@@ -64,7 +64,7 @@ public class ChatMessageController {
         logger.info("현재 채팅방 사용자: {}", roomSessions);
 
         chatMessageService.markMessagesAsRead(roomId, userId);
-        messagingTemplate.convertAndSend("/topic/users/" + roomId, ApiResponse.success(userInfo));
+        messagingTemplate.convertAndSend("/topic/users/" + roomId, ApiResponse.success(chatRoomTypeInfoResponse));
     }
 
     @Operation(summary = "채팅방 퇴장", description = "사용자가 채팅방에서 나갈 때 삭제합니다.")

--- a/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomTypeInfoResponse.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/ChatRoomTypeInfoResponse.java
@@ -1,0 +1,20 @@
+package com.api.stuv.domain.socket.dto;
+
+public record ChatRoomTypeInfoResponse(
+        UserInfoWithContext userInfo,
+        GroupInfo groupInfo
+) {
+    public static ChatRoomTypeInfoResponse privateChat(UserInfoWithContext userInfo) {
+        return new ChatRoomTypeInfoResponse(
+                userInfo,
+                null
+        );
+    }
+
+    public static ChatRoomTypeInfoResponse groupChat(GroupInfo groupInfo) {
+        return new ChatRoomTypeInfoResponse(
+                null,
+                groupInfo
+        );
+    }
+}

--- a/src/main/java/com/api/stuv/domain/socket/dto/UserInfoWithContext.java
+++ b/src/main/java/com/api/stuv/domain/socket/dto/UserInfoWithContext.java
@@ -1,0 +1,9 @@
+package com.api.stuv.domain.socket.dto;
+
+public record UserInfoWithContext(
+        Long userId,
+        String nickname,
+        String profile,
+        String context
+) {}
+

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryCustom.java
@@ -15,4 +15,5 @@ public interface UserRepositoryCustom {
     ImageUrlDTO getCostumeInfoByUserId(Long userId);
     List<UserProfileInfoDTO> findUserInfoByIds(List<Long> userIds);
     Long countNewUserByWeekend(LocalDateTime startDate, LocalDateTime endDate);
+    String findContextByUserId(Long userId);
 }

--- a/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/user/repository/UserRepositoryImpl.java
@@ -167,4 +167,14 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
                 .fetchOne())
                 .orElse(0L);
     }
+
+    @Override
+    public String findContextByUserId(Long userId) {
+        return jpaQueryFactory
+                .select(user.context)
+                .from(user)
+                .where(user.id.eq(userId))
+                .fetchOne();
+    }
+
 }


### PR DESCRIPTION
## 📌 작업 설명
-채팅방 1:1방, 그룹방 정보 응답 오류 수정

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #308 

## 🧑‍💻 요구 사항과 구현 내용
- UserInfo와 UserInfoWithContext 분리 및 context 추가
- PRIVATE 채팅방에서 사용자 정보를 조회할 때 context 포함 여부에 따라 적절한 record 사용
- GROUP 채팅방에서는 본인의 정보를 포함하여 응답하도록 변경
- getChatRoomInfoByRoomName에서 PRIVATE 채팅방의 경우 UserInfoWithContext를 활용하여 context 추가

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
