### PR TITLE
[#313] 코멘트 순서 수정

### DIFF
--- a/src/main/java/com/api/stuv/domain/board/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/board/repository/CommentRepositoryImpl.java
@@ -37,6 +37,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .leftJoin(userCostume).on(user.costumeId.eq(userCostume.id))
                 .leftJoin(imageFile).on(userCostume.costumeId.eq(imageFile.entityId).and(imageFile.entityType.eq(EntityType.COSTUME)))
                 .where(comment.boardId.eq(boardId))
+                .orderBy(comment.createdAt.desc())
                 .offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
     }
 


### PR DESCRIPTION
## 📌 작업 설명
- Board 및 코멘트 가져올 때 순서 createdAt 으로 정렬

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #313 

## 🧑‍💻 요구 사항과 구현 내용
- Board 및 코멘트 가져올 때 순서 createdAt 으로 정렬

## ✅ 피드백 반영사항
- [ ] 피드백 1
- [ ] 피드백 2 

## ✅ PR 포인트 & 궁금한 점
