### PR TITLE
[#316] 메세지 불러오기 페이지네이션 수정

### DIFF
--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -25,23 +25,22 @@ public class ChatController {
     private final ChatRoomMemberService chatRoomMemberService;
     private final TokenUtil tokenUtil;
 
+    @Operation(summary = "채팅방 메시지 조회", description = "채팅방의 메시지를 페이지네이션 방식으로 조회합니다.")
+    @GetMapping("/{roomId}/messages")
+    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessagesByRoomIdPage(
+            @PathVariable String roomId,
+            @RequestParam(required = false) String lastChatId,
+            @RequestParam(defaultValue = "10") int limit) {
+
+        List<ChatMessageResponse> messages = chatMessageService.getMessagesByRoomId(roomId, lastChatId, limit);
+        return ResponseEntity.ok(ApiResponse.success(messages));
+    }
+
     @Operation(summary = "채팅방 목록 조회 API", description = "user가 포함된 채팅방 목록을 가져옵니다.")
     @GetMapping("/list")
     public ResponseEntity<ApiResponse<List<ChatRoomResponse>>> getRoomListBySenderId() {
         List<ChatRoomResponse> roomList = chatRoomDetailService.getSortedRoomListBySenderId(tokenUtil.getUserId());
         return ResponseEntity.ok(ApiResponse.success(roomList));
-    }
-
-    @Operation(summary = "메세지 요청 API", description = "채팅방 메세지를 요청을 합니다.")
-    @GetMapping("/{roomId}/messages")
-    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessagesByRoomIdPage(
-            @PathVariable String roomId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-
-        return ResponseEntity.ok()
-                .body(ApiResponse.success(chatMessageService.getMessagesByRoomId(
-                roomId, PageRequest.of(page, size))));
     }
 
     @Operation(summary = "1:1 채팅방 생성", description = "두 사용자 간의 1:1 채팅방을 생성합니다.")

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryCustom.java
@@ -1,7 +1,12 @@
 package com.api.stuv.domain.socket.repository;
 
+import com.api.stuv.domain.socket.entity.ChatMessage;
+
+import java.util.List;
+
 public interface ChatMessageRepositoryCustom {
     void updateManyReadBy(String roomId, Long userId);
     int countUnreadMessages(String roomId, Long userId);
+    List<ChatMessage> findMessagesByRoomIdWithPagination(String roomId, String lastChatId, int limit);
 
 }

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryImpl.java
@@ -60,40 +60,13 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
         Query query = new Query();
         query.addCriteria(Criteria.where("room_id").is(roomId));
 
-        // lastChatId가 존재하면, 해당 _id보다 작은 메시지만 조회 (즉, 이전 메시지)
         if (lastChatId != null && !lastChatId.isEmpty()) {
             query.addCriteria(Criteria.where("_id").lt(new ObjectId(lastChatId)));
         }
 
-        // 최신 메시지부터 정렬
         query.with(Sort.by(Sort.Direction.DESC, "created_at"));
         query.limit(limit);
 
         return mongoTemplate.find(query, ChatMessage.class);
     }
-
-//    @Override
-//    public List<ChatMessage> findMessagesByRoomIdWithPagination(String roomId, String lastChatId, int limit) {
-//        Query query = new Query();
-//        query.addCriteria(Criteria.where("room_id").is(roomId));
-//
-//        // lastChatId가 존재하면 해당 ID 포함하여 limit개 가져오기
-//        if (lastChatId != null && !lastChatId.isEmpty()) {
-//            query.addCriteria(Criteria.where("_id").lte(new ObjectId(lastChatId))); // lastChatId 포함
-//        }
-//
-//        // 최신순 정렬 후 limit 개수 가져오기
-//        query.with(Sort.by(Sort.Direction.DESC, "created_at"));
-//        query.limit(limit);
-//
-//        List<ChatMessage> messages = mongoTemplate.find(query, ChatMessage.class);
-//
-//        // lastChatId가 없을 때 최신 메시지 limit개 가져오기
-//        if (lastChatId == null || lastChatId.isEmpty()) {
-//            messages = mongoTemplate.find(query, ChatMessage.class);
-//        }
-//
-//        return messages;
-//    }
-
 }

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.api.stuv.domain.socket.repository;
 
 import com.api.stuv.domain.socket.entity.ChatMessage;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -53,4 +54,46 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
         }
         return unreadCount;
     }
+
+    @Override
+    public List<ChatMessage> findMessagesByRoomIdWithPagination(String roomId, String lastChatId, int limit) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("room_id").is(roomId));
+
+        // lastChatId가 존재하면, 해당 _id보다 작은 메시지만 조회 (즉, 이전 메시지)
+        if (lastChatId != null && !lastChatId.isEmpty()) {
+            query.addCriteria(Criteria.where("_id").lt(new ObjectId(lastChatId)));
+        }
+
+        // 최신 메시지부터 정렬
+        query.with(Sort.by(Sort.Direction.DESC, "created_at"));
+        query.limit(limit);
+
+        return mongoTemplate.find(query, ChatMessage.class);
+    }
+
+//    @Override
+//    public List<ChatMessage> findMessagesByRoomIdWithPagination(String roomId, String lastChatId, int limit) {
+//        Query query = new Query();
+//        query.addCriteria(Criteria.where("room_id").is(roomId));
+//
+//        // lastChatId가 존재하면 해당 ID 포함하여 limit개 가져오기
+//        if (lastChatId != null && !lastChatId.isEmpty()) {
+//            query.addCriteria(Criteria.where("_id").lte(new ObjectId(lastChatId))); // lastChatId 포함
+//        }
+//
+//        // 최신순 정렬 후 limit 개수 가져오기
+//        query.with(Sort.by(Sort.Direction.DESC, "created_at"));
+//        query.limit(limit);
+//
+//        List<ChatMessage> messages = mongoTemplate.find(query, ChatMessage.class);
+//
+//        // lastChatId가 없을 때 최신 메시지 limit개 가져오기
+//        if (lastChatId == null || lastChatId.isEmpty()) {
+//            messages = mongoTemplate.find(query, ChatMessage.class);
+//        }
+//
+//        return messages;
+//    }
+
 }


### PR DESCRIPTION
## 📌 작업 설명
- 채팅 메시지 페이징 조회 개선 및 중복 조회 방지

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #316 

## 🧑‍💻 요구 사항과 구현 내용
- ChatMessageRepository 생성 및 페이징 메시지 조회 쿼리 추가
- ChatController에 메시지 조회 API 수정
- 메시지 조회 시 중복된 `UserInfo` 조회 방지

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
