### PR TITLE
[#340] 읽음 상태 업데이트 소켓 통신 변경

### DIFF
--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -36,6 +36,16 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.success(messages));
     }
 
+    @Operation(summary = "채팅방 메시지 범위 조회", description = "마지막 메시지부터 특정 메시지(lastChatId)까지 조회합니다.")
+    @GetMapping("/{roomId}/messages/until")
+    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessagesUntilLastChatId(
+            @PathVariable String roomId,
+            @RequestParam String lastChatId) {
+
+        List<ChatMessageResponse> messages = chatMessageService.getMessagesUntilLastChatId(roomId, lastChatId);
+        return ResponseEntity.ok(ApiResponse.success(messages));
+    }
+
     @Operation(summary = "채팅방 목록 조회 API", description = "user가 포함된 채팅방 목록을 가져옵니다.")
     @GetMapping("/list")
     public ResponseEntity<ApiResponse<List<ChatRoomResponse>>> getRoomListBySenderId() {

--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatMessageController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatMessageController.java
@@ -65,6 +65,11 @@ public class ChatMessageController {
 
         chatMessageService.markMessagesAsRead(roomId, userId);
         messagingTemplate.convertAndSend("/topic/users/" + roomId, ApiResponse.success(chatRoomTypeInfoResponse));
+
+        Map<String, String> response = new HashMap<>();
+        response.put("userId", String.valueOf(userId));
+
+        messagingTemplate.convertAndSend("/topic/read/" + roomId, ApiResponse.success(response));
     }
 
     @Operation(summary = "채팅방 퇴장", description = "사용자가 채팅방에서 나갈 때 삭제합니다.")
@@ -143,25 +148,5 @@ public class ChatMessageController {
             }
         }
     }
-
-    @Operation(summary = "읽음 상태 업데이트", description = "채팅방의 메시지를 읽음 처리로 변경합니다.")
-    @MessageMapping("/chat/read")
-    public void updateReadBy(@Payload ReadMessageRequest readMessageRequest,
-                             @Header(value = "page", required = false) Integer page,
-                             @Header(value = "size", required = false) Integer size) {
-
-        int pageValue = (page != null) ? page : 0;
-        int sizeValue = (size != null) ? size : 10;
-
-        chatMessageService.markMessagesAsRead(readMessageRequest.roomId(), readMessageRequest.userId());
-
-        List<ReadByResponse> updatedReadByList = chatMessageService.getReadByForMessages(
-                readMessageRequest.roomId(),
-                PageRequest.of(pageValue, sizeValue)
-        );
-
-        messagingTemplate.convertAndSend("/topic/read/" + readMessageRequest.roomId(), ApiResponse.success((updatedReadByList)));
-    }
-
 
 }

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryCustom.java
@@ -8,5 +8,6 @@ public interface ChatMessageRepositoryCustom {
     void updateManyReadBy(String roomId, Long userId);
     int countUnreadMessages(String roomId, Long userId);
     List<ChatMessage> findMessagesByRoomIdWithPagination(String roomId, String lastChatId, int limit);
+    List<ChatMessage> findMessagesUntilLastChatId(String roomId, String lastChatId);
 
 }

--- a/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/api/stuv/domain/socket/repository/ChatMessageRepositoryImpl.java
@@ -69,4 +69,15 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
 
         return mongoTemplate.find(query, ChatMessage.class);
     }
+
+    public List<ChatMessage> findMessagesUntilLastChatId(String roomId, String lastChatId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("roomId").is(roomId));
+
+        query.addCriteria(Criteria.where("_id").gte(new ObjectId(lastChatId)));
+
+        query.with(Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        return mongoTemplate.find(query, ChatMessage.class);
+    }
 }

--- a/src/main/java/com/api/stuv/domain/socket/service/ChatMessageService.java
+++ b/src/main/java/com/api/stuv/domain/socket/service/ChatMessageService.java
@@ -65,6 +65,36 @@ public class ChatMessageService {
                 .collect(Collectors.toList());
     }
 
+    public List<ChatMessageResponse> getMessagesUntilLastChatId(String roomId, String lastChatId) {
+        List<ChatMessage> messages = chatMessageRepository.findMessagesUntilLastChatId(roomId, lastChatId);
+        int totalMembers = chatRoomMemberService.getRoomMemberCount(roomId);
+        Collections.reverse(messages);
+        Map<Long, UserInfo> userInfoCache = new HashMap<>();
+
+        return messages.stream()
+                .map(chatMessage -> {
+                    Long senderId = chatMessage.getSenderId();
+                    UserInfo userInfo = userInfoCache.get(senderId);
+
+                    if (userInfo == null) {
+                        String senderNickname = (senderId != null) ? userRepository.findNicknameByUserId(senderId) : null;
+                        ImageUrlDTO response = (senderId != null) ? userRepository.getCostumeInfoByUserId(senderId) : null;
+                        String senderProfile = (response != null)
+                                ? s3ImageService.generateImageFile(EntityType.COSTUME, response.entityId(), response.newFileName())
+                                : null;
+
+                        userInfo = new UserInfo(senderId, senderNickname, senderProfile);
+                        userInfoCache.put(senderId, userInfo);
+                    }
+
+                    int readByCount = (chatMessage.getReadBy() != null) ? chatMessage.getReadBy().size() : 0;
+
+                    return ChatMessageResponse.from(chatMessage, userInfo, totalMembers - readByCount);
+                })
+                .collect(Collectors.toList());
+    }
+
+
     // 메시지 저장
     @Transactional
     public ChatMessageResponse saveMessage(ChatMessageRequest request) {


### PR DESCRIPTION
## 📌 작업 설명
- 읽음 상태 업데이트 소켓 통신 변경

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #340 

## 🧑‍💻 요구 사항과 구현 내용
- /chat/read 삭제 후 /chat/join으로 병합
- /topic/read/ 응답은 userId로 변경
- 특정 메세지까지 조회하는 /{roomId}/messages/until 추가
- getMessagesUntilLastChatId 서비스 추가


## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
