### PR TITLE
[#347] 코스튬 변경 시 채팅방 프로필 변경

### DIFF
--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -25,18 +25,6 @@ public class ChatController {
     private final ChatRoomMemberService chatRoomMemberService;
     private final TokenUtil tokenUtil;
 
-    //    삭제 =========================================================
-    @Operation(summary = "채팅방 목록 API", description = "user가 포함된 채팅방 목록을 가져옵니다.")
-    @GetMapping("/{senderId}")
-    public ResponseEntity<ApiResponse<List<String>>> getRoomsBySenderId(
-            @PathVariable Long senderId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-
-        return ResponseEntity.ok()
-                .body(ApiResponse.success((chatRoomDetailService.getRoomIdsBySenderId(senderId))));
-    }
-
     @Operation(summary = "채팅방 메시지 조회", description = "채팅방의 메시지를 페이지네이션 방식으로 조회합니다.")
     @GetMapping("/{roomId}/messages")
     public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessagesByRoomIdPage(

--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatMessageController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatMessageController.java
@@ -73,9 +73,6 @@ public class ChatMessageController {
             return users;
         });
 
-        chatRoomMemberService.userLeaveRoom(userId);
-//        레디스로 옮기기 -> TTL
-
         logger.info("{} 사용자가 채팅방 {}에서 나감", userId, roomId);
         logger.info("현재 채팅방 사용자: {}", roomCache);
     }

--- a/src/main/java/com/api/stuv/domain/socket/service/ChatRoomDetailService.java
+++ b/src/main/java/com/api/stuv/domain/socket/service/ChatRoomDetailService.java
@@ -27,22 +27,6 @@ public class ChatRoomDetailService {
     private final S3ImageService s3ImageService;
     private final ChatRoomMemberService chatRoomMemberService;
 
-
-    // 삭제 =========================================================
-    public List<String> getRoomIdsBySenderId(Long senderId) {
-        List<ChatRoom> chatRooms = chatRoomRepository.findByMembersContaining(senderId);
-
-        if (chatRooms.isEmpty()) {
-            throw new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND);
-        }
-
-        return chatRooms
-                .stream()
-                .map(ChatRoom::getRoomId)
-                .distinct()
-                .collect(Collectors.toList());
-    }
-
     public String createPrivateChatRoom(Long userId1, Long userId2) {
         List<Long> sortedIds = Arrays.asList(userId1, userId2);
         Collections.sort(sortedIds);

--- a/src/main/java/com/api/stuv/domain/user/service/UserService.java
+++ b/src/main/java/com/api/stuv/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.api.stuv.domain.image.entity.EntityType;
 import com.api.stuv.domain.image.entity.ImageFile;
 import com.api.stuv.domain.image.repository.ImageFileRepository;
 import com.api.stuv.domain.image.service.S3ImageService;
+import com.api.stuv.domain.socket.service.ChatRoomMemberService;
 import com.api.stuv.domain.timer.repository.StudyTimeRepository;
 import com.api.stuv.domain.user.dto.*;
 import com.api.stuv.domain.user.dto.request.*;
@@ -47,6 +48,7 @@ public class UserService {
     private final EmailProvider  emailProvider;
     private final RedisService redisService;
     private final S3ImageService s3ImageService;
+    private final ChatRoomMemberService chatRoomMemberService;
     private final RandomName randomName;
     private final TokenUtil tokenUtil;
     private final ImageFileRepository imageFileRepository;
@@ -305,6 +307,8 @@ public class UserService {
                         newFilename.getNewFilename());
 
         ChangeUserCostume changeUserCostume = new ChangeUserCostume(url);
+
+        chatRoomMemberService.updateUserProfileInCache(userId, url);
 
         return changeUserCostume;
     }


### PR DESCRIPTION
## 📌 작업 설명
- 코스튬 변경 시 ChatRoomMemberService의 Redis 캐시 업데이트

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #347 

## 🧑‍💻 요구 사항과 구현 내용
- changeUserCostume() 실행 시 변경된 프로필 URL을 Redis에 반영
- ChatRoomMemberService에 updateUserProfileInCache() 추가하여 캐시 업데이트
- 기존 UserInfo 조회 후 프로필 정보만 변경하여 Redis에 저장

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
