### PR TITLE
[#354] 채팅방 메시지 범위 조회 응답 예외 처리

### DIFF
--- a/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
+++ b/src/main/java/com/api/stuv/domain/socket/controller/ChatController.java
@@ -40,7 +40,7 @@ public class ChatController {
     @GetMapping("/{roomId}/messages/until")
     public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessagesUntilLastChatId(
             @PathVariable String roomId,
-            @RequestParam String lastChatId) {
+            @RequestParam(required = false) String lastChatId) {
 
         List<ChatMessageResponse> messages = chatMessageService.getMessagesUntilLastChatId(roomId, lastChatId);
         return ResponseEntity.ok(ApiResponse.success(messages));

--- a/src/main/java/com/api/stuv/domain/socket/service/ChatMessageService.java
+++ b/src/main/java/com/api/stuv/domain/socket/service/ChatMessageService.java
@@ -56,16 +56,23 @@ public class ChatMessageService {
 
     //특정 메시지(lastChatId)까지 조회
     public List<ChatMessageResponse> getMessagesUntilLastChatId(String roomId, String lastChatId) {
+        if (lastChatId == null) {
+            return Collections.emptyList();
+        }
+
         List<ChatMessage> messages = chatMessageRepository.findMessagesUntilLastChatId(roomId, lastChatId);
+
+        if (messages.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         int totalMembers = chatRoomMemberService.getRoomMemberCount(roomId);
         Collections.reverse(messages);
 
         return messages.stream()
                 .map(chatMessage -> {
                     Long senderId = chatMessage.getSenderId();
-
                     UserInfo userInfo = chatRoomMemberService.getUserInfo(senderId);
-
                     int readByCount = (chatMessage.getReadBy() != null) ? chatMessage.getReadBy().size() : 0;
 
                     return ChatMessageResponse.from(chatMessage, userInfo, totalMembers - readByCount);


### PR DESCRIPTION
## 📌 작업 설명
- lastChatId가 null이거나 메시지가 없을 때 빈 배열 반환

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #354 

## 🧑‍💻 요구 사항과 구현 내용
- getMessagesUntilLastChatId()에서 lastChatId가 null이면 빈 리스트 반환
- findMessagesUntilLastChatId()에서 조회된 메시지가 없을 경우 빈 리스트 반환

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
