### PR TITLE
[#353] 로그인 access토큰 블랙리스트 설정

### DIFF
--- a/src/main/java/com/api/stuv/domain/auth/jwt/JWTUtil.java
+++ b/src/main/java/com/api/stuv/domain/auth/jwt/JWTUtil.java
@@ -34,6 +34,10 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
     }
 
+    public Date getExpiration(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration();
+    }
+
     public Boolean isExpired(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }

--- a/src/main/java/com/api/stuv/domain/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/api/stuv/domain/auth/jwt/LoginFilter.java
@@ -99,11 +99,11 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         }
 
         //토큰 생성
-        String access = jwtUtil.createJwt("access", userId, email, role, 86400000L);
-        String refresh = jwtUtil.createJwt("refresh", userId, email, role, 86400000L);
+        String access = jwtUtil.createJwt("access", userId, email, role, 3600000L); //1시간
+        String refresh = jwtUtil.createJwt("refresh", userId, email, role, 604800000L); //7일
 
         //refresh 토큰 저장
-        redisService.save(refresh, email, Duration.ofDays(1));
+        redisService.save(refresh, email, Duration.ofDays(7));
 
         //응답 설정
         response.setHeader("access", access);

--- a/src/main/java/com/api/stuv/domain/auth/service/ReissueService.java
+++ b/src/main/java/com/api/stuv/domain/auth/service/ReissueService.java
@@ -23,7 +23,7 @@ public class ReissueService {
         String role = jwtUtil.getRole(refreshToken);
         Long userId = jwtUtil.getUserId(refreshToken);
 
-        return jwtUtil.createJwt("access",userId, email, role, 600_000L); // 10분
+        return jwtUtil.createJwt("access",userId, email, role, 3600000L); // 1시간
     }
 
     public String reissueRefreshToken(String refreshToken) {
@@ -33,11 +33,11 @@ public class ReissueService {
         String role = jwtUtil.getRole(refreshToken);
         Long userId = jwtUtil.getUserId(refreshToken);
 
-        String newRefreshToken = jwtUtil.createJwt("refresh", userId, email, role, 86400000L);
+        String newRefreshToken = jwtUtil.createJwt("refresh", userId, email, role, 604800000L); //7일
         redisService.delete(refreshToken);
-        redisService.save(newRefreshToken, email, Duration.ofDays(1));
+        redisService.save(newRefreshToken, email, Duration.ofDays(7));
 
-        return  newRefreshToken;// 24시간
+        return  newRefreshToken;
     }
 
     private void validateRefreshToken(String refreshToken) {

--- a/src/main/java/com/api/stuv/domain/user/service/KakaoService.java
+++ b/src/main/java/com/api/stuv/domain/user/service/KakaoService.java
@@ -72,11 +72,11 @@ public class KakaoService {
         }
 
         //토큰 생성
-        String access = jwtUtil.createJwt("access", userId, email, role, 600000L);
-        String refresh = jwtUtil.createJwt("refresh", userId, email, role, 86400000L);
+        String access = jwtUtil.createJwt("access", userId, email, role, 3600000L); //1시간
+        String refresh = jwtUtil.createJwt("refresh", userId, email, role, 604800000L); //7일
 
         //refresh 토큰 저장
-        redisService.save(refresh, email, Duration.ofDays(1));
+        redisService.save(refresh, email, Duration.ofDays(7));
 
         //응답 설정
         response.setHeader("access", access);

--- a/src/main/java/com/api/stuv/global/config/SecurityConfig.java
+++ b/src/main/java/com/api/stuv/global/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
                 .requestMatchers("/admin").hasRole("ADMIN")
                 .requestMatchers("/reissue").permitAll()
                 .anyRequest().permitAll())
-                .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class)
+                .addFilterBefore(new JWTFilter(jwtUtil, redisService), LoginFilter.class)
                 .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, redisService), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new CustomLogoutFilter(jwtUtil, redisService), LogoutFilter.class)
                 .sessionManagement((session) -> session


### PR DESCRIPTION
## 📌 작업 설명
- 이전에 로그인했던 사용자의 access 토큰을 블랙리스트에 올려 재접근을 막는 기능 구현

## 🔔 관련 이슈
- 이 PR 이 해결하려는 관련 이슈 번호 : #353 

## 🧑‍💻 요구 사항과 구현 내용
- 로그아웃 시 access 토큰의 만료 기간이 아직 남아있다면 redis에 저장해 재접근하지 못하도록 함
- access, refresh 토큰의 만료기간 10분, 1일에서 1시간, 7일로 변경

## ✅ 피드백 반영사항
- [ ] 피드백 1
- [ ] 피드백 2 

## ✅ PR 포인트 & 궁금한 점
